### PR TITLE
Removed reference to articles

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -110,15 +110,9 @@ adsl %>%
 
 # Where to go from here?
 
-<br>
+Please check out the [Get Started](https://atorus-research.github.io/xportr/articles/xportr.html) for more information.
 
-Please check out the 3 articles within the Articles Tab:
-
- 1) How to write out an xpt file with `xportr`
- 
- 2) Drilling down with `xportr` checks
- 
- 3) Interfacing with the `metacore` package.
+We are in talks with other Pharma companies involved with the `{pharmaverse}` to enhance this package to play well with other downstream and upstream packages.  
 
 # References
 

--- a/README.md
+++ b/README.md
@@ -102,15 +102,13 @@ adsl %>%
 
 # Where to go from here?
 
-<br>
+Please check out the [Get
+Started](https://atorus-research.github.io/xportr/articles/xportr.html)
+for more information.
 
-Please check out the 3 articles within the Articles Tab:
-
-1.  How to write out an xpt file with `xportr`
-
-2.  Drilling down with `xportr` checks
-
-3.  Interfacing with the `metacore` package.
+We are in talks with other Pharma companies involved with the
+`{pharmaverse}` to enhance this package to play well with other
+downstream and upstream packages.
 
 # References
 


### PR DESCRIPTION
I took out those articles that Ross was trying to find

Can you see if the cli checks and x's render appropriately?  Mine don't seem to be displaying correctly.  

![image](https://user-images.githubusercontent.com/10111024/145487547-c2bd98b9-5407-4fba-ad3a-6c213482fe36.png)

But they do in the rmarkdown chunks:

![image](https://user-images.githubusercontent.com/10111024/145487598-3d7aca8c-73f3-4f93-a724-3312e2cdd3ba.png)
