### PR TITLE
More helpful error message for invalid formats

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v1
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -39,8 +39,8 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: rcmdcheck
 
-      - uses: r-lib/actions/check-r-package@v1
+      - uses: r-lib/actions/check-r-package@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,10 @@ Authors@R:
            family = "Didenko",
            email = "Ross.Didenko@AtorusResearch.com",
            role = "aut"),
+    person(given = "Zelos",
+           family = "Zhu",
+           email = "Zelos.Zhu@AtorusResearch.com",
+           role = "aut"),
     person(given = "Atorus/GSK JPT",
            role = "cph")
     )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: xportr
 Title: Utilities to Output CDISC SDTM/ADaM XPT Files
-Version: 0.1.0
+Version: 0.1.0.9000
 Authors@R: 
     c(
     person(given = "Eli",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.3
 Suggests: 
     testthat (>= 3.0.0),
     withr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: xportr
 Title: Utilities to Output CDISC SDTM/ADaM XPT Files
-Version: 0.1.0.9000
+Version: 0.2.0
 Authors@R: 
     c(
     person(given = "Eli",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 # xportr 0.1.0.9000 (development)
-* Added a new validation test that errors when users pass invalid formats. Thanks to @zdz2101!
+* Added a new validation test that errors when users pass invalid formats (#60 #64). Thanks to @zdz2101!
 
 # xportr 0.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# xportr 0.1.0.9000 (development)
+# xportr 0.2.0
 * Added a new validation test that errors when users pass invalid formats (#60 #64). Thanks to @zdz2101!
 
 # xportr 0.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# xportr 0.1.0.9000 (development)
+* Added a new validation test that errors when users pass invalid formats. Thanks to @zdz2101!
+
 # xportr 0.1.0
 
 Beta release for xportr 

--- a/R/utils-xportr.R
+++ b/R/utils-xportr.R
@@ -92,7 +92,7 @@ xpt_validate <- function(data) {
   }
   
   # 4.0 Format Types ----
-  formats <- tolower(extract_attr(adsl2, attr = "format.sas"))
+  formats <- tolower(extract_attr(data, attr = "format.sas"))
   
   ## The usual expected formats in clinical trials: characters, dates
   expected_formats <- c(NA, 

--- a/R/utils-xportr.R
+++ b/R/utils-xportr.R
@@ -99,8 +99,10 @@ xpt_validate <- function(data) {
                         '',
                         paste("$", 1:200, ".", sep = ""),
                         paste("date", 5:11, ".", sep = ""), 
-                        paste('datetime', 7:40, ".", sep = ""),
-                        paste('yymmdd', 2:10, ".", sep = ""))
+                        paste("datetime", 7:40, ".", sep = ""),
+                        paste("yymmdd", 2:10, ".", sep = ""),
+                        paste("mmddyy", 2:10, ".", sep = ""),
+                        paste("ddmmyy", 2:10, ".", sep = ""))
   
   chk_formats <- formats[which(!formats %in% expected_formats)]
   

--- a/man/xportr-package.Rd
+++ b/man/xportr-package.Rd
@@ -24,6 +24,7 @@ Authors:
   \item Vignesh  Thanikachalam \email{vignesh.x.thanikachalam@gsk.com}
   \item Ben Straub \email{ben.x.straub@gsk.com}
   \item Ross Didenko \email{Ross.Didenko@AtorusResearch.com}
+  \item Zelos Zhu \email{Zelos.Zhu@AtorusResearch.com}
 }
 
 Other contributors:

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -48,3 +48,19 @@ test_that("Error message given if file name is greater than 8 characters",{
   
 
 })
+
+test_that("Format message given if unexpected formats", {
+  tmpdir <- tempdir()
+  tmp <- file.path(tmpdir, "xyz.xpt")
+  
+  on.exit(unlink(tmpdir))
+  
+  df <- data.frame(USUBJID = c("1001", "1002", "10003"),
+                   AGE = c("M", "F", "M"),
+                   BIRTHDT = as.Date(c("2001-01-01", "1997-11-11", "1995-12-12"), "%Y-%m-%d"))
+  
+  # Forget the period in date9.
+  attr(df$BIRTHDT, "format.sas") <- "date9"
+  
+  expect_error(xportr_write(df, tmp))
+})


### PR DESCRIPTION
Per #60 and #64 , users seem to encounter this error with relative frequency: 

"Error: Writing failure: A provided format string could not be understood."  

I believe this is actually a `haven` error-message coming from line 55 in `R/write.R` :  
`write_xpt(data, path = path, version = 5, name = name)`

To remedy this, I propose to add an additional format check inside `xpt_validate()` which is called at line 47 of `R/write.R`, but changes are contained inside `R/utils-xportr.R`