### PR TITLE
Add logic to convert any null or NA formats to "" for haven.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # xportr 0.2.0
 * Added a new validation test that errors when users pass invalid formats (#60 #64). Thanks to @zdz2101!
+* Fixed an issue where xportr_format could pass invalid formats to haven::write_xpt.
 
 # xportr 0.1.0
 

--- a/R/format.R
+++ b/R/format.R
@@ -74,5 +74,11 @@ xportr_format <- function(.df, metacore, domain = NULL, verbose = getOption("xpo
     attr(.df[[i]], "format.sas")  <- format[[i]]
   }
   
+  # Convert NA formats to "" for haven
+  for (i in seq_len(ncol(.df))) {
+    if (is.na(attr(.df[[i]], "format.sas")) || is.null(attr(.df[[i]], "format.sas"))) 
+      attr(.df[[i]], "format.sas") <- ""
+  }
+  
   .df
 }

--- a/R/format.R
+++ b/R/format.R
@@ -61,14 +61,17 @@ xportr_format <- function(.df, metacore, domain = NULL, verbose = getOption("xpo
   } else {
     metadata <- metacore
   }
+  
+  filtered_metadata <- metadata %>%
+    filter(!!sym(variable_name) %in% names(.df))
 
-    
-  format <- metadata %>%
+  
+  format <- filtered_metadata %>%
     select(!!sym(format_name))  %>%
     unlist() %>%
     toupper()
-  
-  names(format) <- metadata[[variable_name]]
+
+  names(format) <- filtered_metadata[[variable_name]]
   
   for (i in names(format)) {
     attr(.df[[i]], "format.sas")  <- format[[i]]

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -54,20 +54,26 @@ test_that("Expect error if any label exceeds 40 character", {
 })
 
 test_that("SAS format", {
-  df <- data.frame(x = 1, y = 2)
-  varmeta <- data.frame(dataset  = rep("df", 2), 
-                    variable = c("x", "y"), 
-                    format = c("date9.", "datetime20."))
+  df <- data.frame(x = 1, y = 2, z = 3)
+  varmeta <- data.frame(dataset  = rep("df", 3), 
+                    variable = c("x", "y", "z"), 
+                    format = c("date9.", "datetime20.", NA))
   
   extract_format <- function(.x) {
-    vapply(.x, function(.x) attr(.x, "format.sas"), character(1), USE.NAMES = FALSE) 
+    format_ <- character(3)
+    for (i in 1:3) {
+      print(attr(.x[[i]], "format.sas"))
+      format_[i] <- attr(.x[[i]], "format.sas")
+    }
+    format_
   }
   
   out <- xportr_format(df, varmeta)
   
-  expect_equal(extract_format(out), c("DATE9.", "DATETIME20."))
+  expect_equal(extract_format(out), c("DATE9.", "DATETIME20.", ""))
   expect_equal(dput(out), structure(list(x = structure(1, format.sas = "DATE9."),
-                                         y = structure(2, format.sas = "DATETIME20.")),
+                                         y = structure(2, format.sas = "DATETIME20."),
+                                         z = structure(3, format.sas = "")),
                                     row.names = c(NA, -1L), class = "data.frame"))
 })
 

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -1,3 +1,12 @@
+
+extract_format <- function(.x) {
+  format_ <- character(length(.x))
+  for (i in 1:length(.x)) {
+    format_[i] <- attr(.x[[i]], "format.sas")
+  }
+  format_
+}
+
 test_that("Variable label", {
   df <- data.frame(x = "a", y = "b")
   varmeta <- data.frame(dataset  = rep("df", 2), 
@@ -53,27 +62,35 @@ test_that("Expect error if any label exceeds 40 character", {
                "dataset label must be 40 characters or less")
 })
 
-test_that("SAS format", {
-  df <- data.frame(x = 1, y = 2, z = 3)
+test_that("xportr_format will set formats as expected", {
+  df <- data.frame(x = 1, y = 2)
+  varmeta <- data.frame(dataset  = rep("df", 2), 
+                        variable = c("x", "y"), 
+                        format = c("date9.", "datetime20."))
+  
+
+  
+  out <- xportr_format(df, varmeta)
+  
+  expect_equal(extract_format(out), c("DATE9.", "DATETIME20."))
+  expect_equal(dput(out), structure(list(x = structure(1, format.sas = "DATE9."),
+                                         y = structure(2, format.sas = "DATETIME20.")),
+                                    row.names = c(NA, -1L), class = "data.frame"))
+})
+
+test_that("xportr_format will handle NA values and won't error", {
+  df <- data.frame(x = 1, y = 2, z = 3, a = 4)
   varmeta <- data.frame(dataset  = rep("df", 4), 
                     variable = c("x", "y", "z", "abc"), 
                     format = c("date9.", "datetime20.", NA, "text"))
   
-  extract_format <- function(.x) {
-    format_ <- character(3)
-    for (i in 1:3) {
-      print(attr(.x[[i]], "format.sas"))
-      format_[i] <- attr(.x[[i]], "format.sas")
-    }
-    format_
-  }
-  
   out <- xportr_format(df, varmeta)
   
-  expect_equal(extract_format(out), c("DATE9.", "DATETIME20.", ""))
+  expect_equal(extract_format(out), c("DATE9.", "DATETIME20.", "", ""))
   expect_equal(dput(out), structure(list(x = structure(1, format.sas = "DATE9."),
                                          y = structure(2, format.sas = "DATETIME20."),
-                                         z = structure(3, format.sas = "")),
+                                         z = structure(3, format.sas = ""),
+                                         a = structure(4, format.sas = "")),
                                     row.names = c(NA, -1L), class = "data.frame"))
 })
 

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -55,9 +55,9 @@ test_that("Expect error if any label exceeds 40 character", {
 
 test_that("SAS format", {
   df <- data.frame(x = 1, y = 2, z = 3)
-  varmeta <- data.frame(dataset  = rep("df", 3), 
-                    variable = c("x", "y", "z"), 
-                    format = c("date9.", "datetime20.", NA))
+  varmeta <- data.frame(dataset  = rep("df", 4), 
+                    variable = c("x", "y", "z", "abc"), 
+                    format = c("date9.", "datetime20.", NA, "text"))
   
   extract_format <- function(.x) {
     format_ <- character(3)


### PR DESCRIPTION
This closes #69.

Idea here is to remove any null or NA formats and convert them to "". This is due to a limitation in haven that will break any NA 'sas.formats'