### PR TITLE
Don't overwrite label, width, or sas.format in `xportr_type()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# xportr 0.3.0
+* Fixed an issue where xportr_type would overwrite column labels, widths, and "sas.formats"
+
 # xportr 0.2.0
 * Added a new validation test that errors when users pass invalid formats (#60 #64). Thanks to @zdz2101!
 * Fixed an issue where xportr_format could pass invalid formats to haven::write_xpt.

--- a/R/type.R
+++ b/R/type.R
@@ -90,13 +90,14 @@ xportr_type <- function(.df, metacore, domain = NULL,
   is_correct <- sapply(meta_ordered[["type.x"]] == meta_ordered[["type.y"]], isTRUE)
   # Use the original variable iff metadata is missing that variable
   correct_type <- ifelse(is.na(meta_ordered[["type.y"]]), meta_ordered[["type.x"]], meta_ordered[["type.y"]])
-  
+
   # Walk along the columns and coerce the variables. Modifying the columns
   # Directly instead of something like map_dfc to preserve any attributes.
   walk2(correct_type, seq_along(correct_type),
         function(x, i, is_correct) {
           if (!is_correct[i]) {
             orig_attributes <- attributes(.df[[i]])
+            orig_attributes$class <- NULL
             if (correct_type[i] %in% characterTypes)
               .df[[i]] <<- as.character(.df[[i]])
             else .df[[i]] <<- as.numeric(.df[[i]])

--- a/R/type.R
+++ b/R/type.R
@@ -51,7 +51,7 @@ xportr_type <- function(.df, metacore, domain = NULL,
   if (!is.null(attr(.df, "_xportr.df_arg_"))) df_arg <- attr(.df, "_xportr.df_arg_")
   else if (identical(df_arg, ".")) {
     attr(.df, "_xportr.df_arg_") <- get_pipe_call()
-    df_arg <- attr(.df, "_xportr.df_arg_") 
+    df_arg <- attr(.df, "_xportr.df_arg_")
   }
   
   domain <- domain %||% df_arg
@@ -70,7 +70,7 @@ xportr_type <- function(.df, metacore, domain = NULL,
   
   # Current class of table variables
   table_cols_types <- map(.df, first_class)
-  
+
   # Produces a data.frame with Variables, Type.x(Table), and Type.y(metadata)
   meta_ordered <- left_join(
     data.frame(variable = names(.df), type = unlist(table_cols_types)),
@@ -96,9 +96,11 @@ xportr_type <- function(.df, metacore, domain = NULL,
   walk2(correct_type, seq_along(correct_type),
         function(x, i, is_correct) {
           if (!is_correct[i]) {
+            orig_attributes <- attributes(.df[[i]])
             if (correct_type[i] %in% characterTypes)
               .df[[i]] <<- as.character(.df[[i]])
             else .df[[i]] <<- as.numeric(.df[[i]])
+            attributes(.df[[i]]) <<- orig_attributes
           }
         }, is_correct)
   

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -31,7 +31,7 @@ test_that("variable types are coerced as expected and can raise messages", {
                                       Val = "numeric", Param = "character"))})
 
 test_that("xportr_type() retains column attributes, besides class", {
-  adsl <- tibble::tibble(
+  adsl <- dplyr::tibble(
     USUBJID = c(1001, 1002, 1003),
     SITEID = c(001, 002, 003),
     ADATE = readr::parse_date(c("2023-04-11", "2023-04-12", "2023-04-13")),
@@ -39,7 +39,7 @@ test_that("xportr_type() retains column attributes, besides class", {
     SEX = c("M", "F", "M")
   )
   
-  metacore <- tibble::tibble(
+  metacore <- dplyr::tibble(
     dataset = "adsl",
     variable = c("USUBJID", "SITEID", "ADATE", "AGE", "SEX"),
     label = c("Unique Subject Identifier", "Study Site Identifier", "Study Dates", "Age", "Sex"),

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -30,27 +30,34 @@ test_that("variable types are coerced as expected and can raise messages", {
   expect_equal(purrr::map_chr(df4, class), c(Subj = "numeric", Different = "character",
                                       Val = "numeric", Param = "character"))})
 
-test_that("xportr_type() retains column attributes", {
-  adsl <- data.frame(
+test_that("xportr_type() retains column attributes, besides class", {
+  adsl <- tibble::tibble(
     USUBJID = c(1001, 1002, 1003),
     SITEID = c(001, 002, 003),
+    ADATE = readr::parse_date(c("2023-04-11", "2023-04-12", "2023-04-13")),
     AGE = c(63, 35, 27),
     SEX = c("M", "F", "M")
   )
   
-  metacore <- data.frame(
+  metacore <- tibble::tibble(
     dataset = "adsl",
-    variable = c("USUBJID", "SITEID", "AGE", "SEX"),
-    label = c("Unique Subject Identifier", "Study Site Identifier", "Age", "Sex"),
-    type = c("character", "character", "numeric", "character")
+    variable = c("USUBJID", "SITEID", "ADATE", "AGE", "SEX"),
+    label = c("Unique Subject Identifier", "Study Site Identifier", "Study Dates", "Age", "Sex"),
+    type = c("character", "character", "character", "numeric", "character"),
+    length = c(10, 10, 10, 8, 10),
+    format = c(NA, NA, "DATE9.", NA, NA)
   )
   
   df_type_label <- adsl %>%
     xportr_type(metacore) %>%
-    xportr_label(metacore)
+    xportr_label(metacore) %>% 
+    xportr_length(metacore) %>% 
+    xportr_format(metacore)
   
   df_label_type <- adsl %>%
-    xportr_label(metacore) %>%
+    xportr_label(metacore) %>% 
+    xportr_length(metacore) %>% 
+    xportr_format(metacore) %>%
     xportr_type(metacore)
   
   expect_equal(df_type_label, df_label_type)

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -30,3 +30,29 @@ test_that("variable types are coerced as expected and can raise messages", {
   expect_equal(purrr::map_chr(df4, class), c(Subj = "numeric", Different = "character",
                                       Val = "numeric", Param = "character"))})
 
+test_that("xportr_type() retains column attributes", {
+  adsl <- data.frame(
+    USUBJID = c(1001, 1002, 1003),
+    SITEID = c(001, 002, 003),
+    AGE = c(63, 35, 27),
+    SEX = c("M", "F", "M")
+  )
+  
+  metacore <- data.frame(
+    dataset = "adsl",
+    variable = c("USUBJID", "SITEID", "AGE", "SEX"),
+    label = c("Unique Subject Identifier", "Study Site Identifier", "Age", "Sex"),
+    type = c("character", "character", "numeric", "character")
+  )
+  
+  df_type_label <- adsl %>%
+    xportr_type(metacore) %>%
+    xportr_label(metacore)
+  
+  df_label_type <- adsl %>%
+    xportr_label(metacore) %>%
+    xportr_type(metacore)
+  
+  expect_equal(df_type_label, df_label_type)
+})
+

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -39,7 +39,7 @@ test_that("xportr_type() retains column attributes, besides class", {
     SEX = c("M", "F", "M")
   )
   
-  metacore <- dplyr::tibble(
+  metadata <- dplyr::tibble(
     dataset = "adsl",
     variable = c("USUBJID", "SITEID", "ADATE", "AGE", "SEX"),
     label = c("Unique Subject Identifier", "Study Site Identifier", "Study Dates", "Age", "Sex"),
@@ -49,16 +49,16 @@ test_that("xportr_type() retains column attributes, besides class", {
   )
   
   df_type_label <- adsl %>%
-    xportr_type(metacore) %>%
-    xportr_label(metacore) %>% 
-    xportr_length(metacore) %>% 
-    xportr_format(metacore)
+    xportr_type(metadata) %>%
+    xportr_label(metadata) %>% 
+    xportr_length(metadata) %>% 
+    xportr_format(metadata)
   
   df_label_type <- adsl %>%
-    xportr_label(metacore) %>% 
-    xportr_length(metacore) %>% 
-    xportr_format(metacore) %>%
-    xportr_type(metacore)
+    xportr_label(metadata) %>% 
+    xportr_length(metadata) %>% 
+    xportr_format(metadata) %>%
+    xportr_type(metadata)
   
   expect_equal(df_type_label, df_label_type)
 })


### PR DESCRIPTION
Fixes #75

The issue here was that coercing columns with `as.character()` or `as.numeric()` strips all attributes, not just the class attribute that we want to be rid of. I made a change to save attributes besides class (such as width, label, and format.sas), then restore those classes after coercion. I also wrote a test that checks for identical results whether `xportr_type()` is called at the beginning or end of a pipeline.

The function `metacore::set_variable_labels()` was also referenced in the original issue. I cannot find such a function in metacore, so I have not tested against it here. If it sets labels with an attribute like xportr does, this will fix it as well.

Should I ask the original issue filer to install this version for testing?

Please let me know if there's anything you want changed or included in this PR!