### PR TITLE
Closes #82: Increase Test Coverage to 100%

### DIFF
--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -165,7 +165,9 @@ test_that("xportr_df_label: Correctly applies label when data is piped", {
   df <- data.frame(x = "a", y = "b")
   df_meta <- data.frame(dataset = "df", label = "Label")
 
-  df_spec_labeled_df <- df %>% xportr_df_label(df_meta)
+  df_spec_labeled_df <- df %>%
+    xportr_df_label(df_meta) %>%
+    xportr_df_label(df_meta)
 
   expect_equal(attr(df_spec_labeled_df, "label"), "Label")
   expect_equal(

--- a/tests/testthat/test-pkg-load.R
+++ b/tests/testthat/test-pkg-load.R
@@ -1,0 +1,10 @@
+test_that(".onLoad: Unset options get initialised on package load with defaults", {
+  skip_if(getOption("testthat_interactive"))
+  withr::with_options(
+    list(xportr.df_domain_name = NULL),
+    {
+      expect_no_error(.onLoad())
+      expect_equal(getOption("xportr.df_domain_name"), "dataset")
+    }
+  )
+})

--- a/tests/testthat/test-pkg-load.R
+++ b/tests/testthat/test-pkg-load.R
@@ -8,3 +8,14 @@ test_that(".onLoad: Unset options get initialised on package load with defaults"
     }
   )
 })
+
+test_that(".onLoad: Initialised options are retained and not overwritten", {
+  skip_if(getOption("testthat_interactive"))
+  withr::with_options(
+    list(xportr.df_domain_name = "custom_domain"),
+    {
+      expect_no_error(.onLoad())
+      expect_equal(getOption("xportr.df_domain_name"), "custom_domain")
+    }
+  )
+})

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -37,7 +37,7 @@ test_that("xportr_type: Variable types are coerced as expected and can raise mes
   ))
 })
 
-test_that("xportr_type() retains column attributes, besides class", {
+test_that("xportr_type: Variables retain column attributes, besides class", {
   adsl <- dplyr::tibble(
     USUBJID = c(1001, 1002, 1003),
     SITEID = c(001, 002, 003),

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -11,7 +11,7 @@ df <- data.frame(
   Param = c("param1", "param2", "param3")
 )
 
-test_that("variable types are coerced as expected and can raise messages", {
+test_that("xportr_type: Variable types are coerced as expected and can raise messages", {
   expect_message(
     df2 <- xportr_type(df, meta_example),
     "-- Variable type mismatches found. --"

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -63,3 +63,36 @@ test_that("xportr_type() retains column attributes, besides class", {
 
   expect_equal(df_type_label, df_label_type)
 })
+
+
+test_that("xportr_type: expect error when domain is not a character", {
+  df <- data.frame(x = 1, y = 2)
+  df_meta <- data.frame(
+    variable = c("x", "y"),
+    type = "text",
+    label = c("X Label", "Y Label"),
+    length = c(1, 2),
+    common = NA_character_,
+    format = c("date9.", "datetime20.")
+  )
+  expect_error(xportr_type(df, df_meta, domain = 1))
+  expect_error(xportr_type(df, df_meta, domain = NA))
+})
+
+test_that("xportr_type: works fine from metacore spec", {
+  df <- data.frame(x = 1, y = 2)
+  metacore_meta <- suppressWarnings(
+    metacore::metacore(
+      var_spec = data.frame(
+        variable = c("x", "y"),
+        type = "text",
+        label = c("X Label", "Y Label"),
+        length = c(1, 2),
+        common = NA_character_,
+        format = c("date9.", "datetime20.")
+      )
+    )
+  )
+  processed_df <- xportr_type(df, metacore_meta)
+  expect_equal(processed_df$x, "1")
+})

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -1,4 +1,3 @@
-
 meta_example <- data.frame(
   dataset = "df",
   variable = c("Subj", "Param", "Val", "NotUsed"),
@@ -6,29 +5,36 @@ meta_example <- data.frame(
 )
 
 df <- data.frame(
- Subj = as.character(123, 456, 789),
- Different = c("a", "b", "c"),
- Val = c("1", "2", "3"),
- Param = c("param1", "param2", "param3")
+  Subj = as.character(123, 456, 789),
+  Different = c("a", "b", "c"),
+  Val = c("1", "2", "3"),
+  Param = c("param1", "param2", "param3")
 )
 
 test_that("variable types are coerced as expected and can raise messages", {
+  expect_message(
+    df2 <- xportr_type(df, meta_example),
+    "-- Variable type mismatches found. --"
+  )
 
-  expect_message(df2 <- xportr_type(df, meta_example),
-                 "-- Variable type mismatches found. --")
-
-  expect_equal(purrr::map_chr(df2, class), c(Subj = "numeric", Different = "character",
-                                      Val = "numeric", Param = "character"))
+  expect_equal(purrr::map_chr(df2, class), c(
+    Subj = "numeric", Different = "character",
+    Val = "numeric", Param = "character"
+  ))
 
   expect_error(xportr_type(df, meta_example, verbose = "stop"))
 
   expect_warning(df3 <- xportr_type(df, meta_example, verbose = "warn"))
-  expect_equal(purrr::map_chr(df3, class), c(Subj = "numeric", Different = "character",
-                                      Val = "numeric", Param = "character"))
+  expect_equal(purrr::map_chr(df3, class), c(
+    Subj = "numeric", Different = "character",
+    Val = "numeric", Param = "character"
+  ))
 
   expect_message(df4 <- xportr_type(df, meta_example, verbose = "message"))
-  expect_equal(purrr::map_chr(df4, class), c(Subj = "numeric", Different = "character",
-                                      Val = "numeric", Param = "character"))
+  expect_equal(purrr::map_chr(df4, class), c(
+    Subj = "numeric", Different = "character",
+    Val = "numeric", Param = "character"
+  ))
 })
 
 test_that("xportr_type() retains column attributes, besides class", {

--- a/tests/testthat/test-utils-xportr.R
+++ b/tests/testthat/test-utils-xportr.R
@@ -2,11 +2,11 @@ test_that("Get magrittr lhs side value", {
   x <- function(df, var) {
     get_pipe_call()
   }
-  
+
   y <- function(df) {
     get_pipe_call()
   }
-  
+
   expect_equal({
     mtcars %>% x("cyl")
   },
@@ -15,4 +15,28 @@ test_that("Get magrittr lhs side value", {
     mtcars %>% subset(cyl == 6) %>% x("cyl")
   },
   "mtcars")
+})
+
+
+test_that("fmt_vars: the message returns properly formatted variables", {
+  expect_equal(fmt_vars(4), "Variable 4")
+  expect_equal(fmt_vars(4:6), "Variables 4, 5, and 6")
+})
+
+test_that("fmt_labs: the message returns properly formatted labels", {
+  expect_equal(fmt_labs(4), "Label '=4'")
+  expect_equal(fmt_labs(4:6), "Labels '=4', '=5', and '=6'")
+})
+
+test_that("xpt_validate_var_names: ", {
+  xpt_validate_var_names(c("A", "Bajskflas", "2klsd", "asdf_asdf"))
+  expect_equal(1, 1)
+})
+
+test_that("xpt_validate", {
+  df <- data.frame(A = 1, B = 2)
+  attr(df$A, "label") <- "asdfkajsdkj_fhaksjdfkajshdfkajsdfkjhk<jashdfkjah"
+  attr(df$B, "SAStype") <- "list"
+  xpt_validate(df)
+  expect_equal(1, 1)
 })

--- a/tests/testthat/test-utils-xportr.R
+++ b/tests/testthat/test-utils-xportr.R
@@ -7,14 +7,20 @@ test_that("Get magrittr lhs side value", {
     get_pipe_call()
   }
 
-  expect_equal({
-    mtcars %>% x("cyl")
-  },
-  "mtcars")
-  expect_equal({
-    mtcars %>% subset(cyl == 6) %>% x("cyl")
-  },
-  "mtcars")
+  expect_equal(
+    {
+      mtcars %>% x("cyl")
+    },
+    "mtcars"
+  )
+  expect_equal(
+    {
+      mtcars %>%
+        subset(cyl == 6) %>%
+        x("cyl")
+    },
+    "mtcars"
+  )
 })
 
 

--- a/tests/testthat/test-utils-xportr.R
+++ b/tests/testthat/test-utils-xportr.R
@@ -34,15 +34,71 @@ test_that("fmt_labs: the message returns properly formatted labels", {
   expect_equal(fmt_labs(4:6), "Labels '=4', '=5', and '=6'")
 })
 
-test_that("xpt_validate_var_names: ", {
-  xpt_validate_var_names(c("A", "Bajskflas", "2klsd", "asdf_asdf"))
-  expect_equal(1, 1)
+test_that("xpt_validate_var_names: Get error message when the variable is over 8 characters", {
+  expect_equal(
+    xpt_validate_var_names(c("FOO", "BAR", "ABCDEFGHI")),
+    "Variable `ABCDEFGHI` must be 8 characters or less."
+  )
 })
 
-test_that("xpt_validate", {
-  df <- data.frame(A = 1, B = 2)
-  attr(df$A, "label") <- "asdfkajsdkj_fhaksjdfkajshdfkajsdfkjhk<jashdfkjah"
-  attr(df$B, "SAStype") <- "list"
-  xpt_validate(df)
-  expect_equal(1, 1)
+test_that("xpt_validate_var_names: Get error message when the variable does not start with a letter", {
+  expect_equal(
+    xpt_validate_var_names(c("FOO", "2BAR")),
+    "Variable `2BAR` must start with a letter."
+  )
 })
+
+test_that("xpt_validate_var_names: Get error message when the variable contains non-ASCII characters or underscore", {
+  expect_equal(
+    xpt_validate_var_names(c("FOO", "BAR", "FOO-BAR")),
+    c(
+      "Variable `FOO-BAR` cannot contain any non-ASCII, symbol or underscore characters.",
+      "Variable `FOO-BAR` cannot contain any lowercase characters."
+    )
+  )
+  expect_equal(
+    xpt_validate_var_names(c("FOO", "BAR", "FOO_BAR")),
+    c(
+      "Variable `FOO_BAR` cannot contain any non-ASCII, symbol or underscore characters.",
+      "Variable `FOO_BAR` cannot contain any lowercase characters."
+    )
+  )
+})
+
+test_that("xpt_validate_var_names: Get error message when tje variable contains lowercase character", {
+  xpt_validate_var_names(c("FOO", "bar"))
+  expect_equal(
+    xpt_validate_var_names(c("FOO", "bar")),
+    "Variable `bar` cannot contain any lowercase characters."
+  )
+})
+
+test_that("xpt_validate: Get error message when the label contains non-ASCII, symbol or special characters", {
+  df <- data.frame(A = 1, B = 2)
+  attr(df$A, "label") <- "foo<bar"
+  expect_equal(
+    xpt_validate(df),
+    "Label 'A=foo<bar' cannot contain any non-ASCII, symbol or special characters."
+  )
+})
+
+test_that("xpt_validate: Get error message when the label contains over 40 characters", {
+  df <- data.frame(A = 1, B = 2)
+  long_label <- paste(rep("a", 41), collapse = "")
+  attr(df$A, "label") <- long_label
+  expect_equal(
+    xpt_validate(df),
+    paste0("Label 'A=", long_label, "' must be 40 characters or less.")
+  )
+})
+
+test_that("xpt_validate: Get error message when the variable type is invalid", {
+  df <- data.frame(A = 1, B = 2)
+  attr(df$A, "SAStype") <- "integer"
+  attr(df$B, "SAStype") <- "list"
+  expect_equal(
+    xpt_validate(df),
+    "Variables `A` and `B` must have a valid type."
+  )
+})
+

--- a/tests/testthat/test-utils-xportr.R
+++ b/tests/testthat/test-utils-xportr.R
@@ -101,4 +101,3 @@ test_that("xpt_validate: Get error message when the variable type is invalid", {
     "Variables `A` and `B` must have a valid type."
   )
 })
-


### PR DESCRIPTION
### Related Issues
- #82 

### Changes Description

1. Adds tests for `.onLoad()` function that sets the default options when the package is loaded
2. Increase the coverage for `xportr_df_label()` by piping second time - So we also test the case when the `_xportr.df_arg_` is already set.
3. Increase the coverage for `xportr_type()` by covering two cases:
    - When the passed domain is not a character
    - When metadata is a metacore object
4. Add a few trivial tests to cover the `utils-xportr.R`
5. Rewrite to cover all the cases handled by the `xportr_write()`

![Screenshot 2023-05-02 at 12 11 38 AM](https://user-images.githubusercontent.com/49812166/235508882-eaf131bc-7721-46da-9d3d-e549f405358f.png)


### Task List

- [x] The spirit of xportr is met in your Pull Request
- [x] Summary of changes filled out in the above Changes Description.  Can be removed or left blank if changes are minor/self-explanatory.
- [x] [This will change to `deval` after the base is merged to deval, so checking it :)]Check that your Pull Request is targeting the `devel` branch, Pull Requests to `main` should use the [Release Pull Request Template](https://github.com/pharmaverse/xportr/blob/main/.github/PULL_REQUEST_TEMPLATE/release.md)
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/).  Use `styler` package and functions to style files accordingly.
- [x] Updated relevant unit tests or have written new unit tests. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Unit-Tests) for conventions used in this package.
- [x] Creation/updated relevant roxygen headers and examples. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers) for conventions used in this package.
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [x] Run `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new/updated functions occur on the "Reference" page.
- [x] Update NEWS.md if the changes pertain to a user-facing function (i.e. it has an @export tag) or documentation aimed at users (rather than developers)
- [x] Address any updates needed for vignettes and/or templates
- [x] Run `R CMD check` locally and address all errors and warnings - `devtools::check()`
- [x] Link the issue Development Panel so that it closes after successful merging. 
- [x] Address all merge conflicts and resolve appropriately 
- [x] Pat yourself on the back for a job well done!  Much love to your accomplishment!