### PR TITLE
Closes #109 Fix the error of unable to build the pkgdown site

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -33,3 +33,9 @@ reference:
   contents: 
   - xportr
 
+- title: internal
+  contents:
+  - cli_theme_tests
+  - expect_attr_width
+  - minimal_metadata
+  - minimal_table


### PR DESCRIPTION
Closes:
- #109 

### Changes Description

1. Adds the test-related internal functions as `internal` so that pkgdown ignores them.

### Task List

- [x] The spirit of xportr is met in your Pull Request
- [x] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [x] Summary of changes filled out in the above Changes Description.  Can be removed or left blank if changes are minor/self-explanatory.
- [x] Check that your Pull Request is targeting the `devel` branch, Pull Requests to `main` should use the [Release Pull Request Template](https://github.com/atorus-research/xportr/tree/94_pr_template/.github/PULL_REQUEST_TEMPLATE)
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/).  Use `styler` package and functions to style files accordingly.
- [x] Updated relevant unit tests or have written new unit tests. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Unit-Tests) for conventions used in this package.
- [x] Creation/updated relevant roxygen headers and examples. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers) for conventions used in this package.
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [x] Run `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new/updated functions occur on the "Reference" page.
- [x] Update NEWS.md if the changes pertain to a user-facing function (i.e. it has an @export tag) or documentation aimed at users (rather than developers)
- [x] Address any updates needed for vignettes and/or templates
- [x] Link the issue Development Panel so that it closes after successful merging. 
- [x] Pat yourself on the back for a job well done!  Much love to your accomplishment!