### PR TITLE
#106 - Adding the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -1,0 +1,33 @@
+name: Bug Report
+description: Something is not working correctly or is not working at all!
+title: "Bug: <Insert Issue Title Here>"
+labels: ["bug", "programming"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Example:** Bug: xportr_format() does not assign SAS format for `DATE9.` variable level metadata
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us what were you expecting to happen before the bug?
+      placeholder: "A bug happened!"
+    validations:
+      required: true
+  - type: textarea
+    id: session-info
+    attributes:
+      label: Session Information
+      description: Use `sessionInfo()` in the R console to gather all the details of your environment when the bug happened.
+      placeholder: "Place the console output here"
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Reproducible Example
+      description: We love code that can reproduce the example. Check out [reprex](https://reprex.tidyverse.org/articles/reprex-dos-and-donts.html)
+      placeholder: "Please give us as many details as you can! The faster we can recreate the bug, the faster we can get a fix in the works.  Warning, Error Messages and Screenshots are also great."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/02_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature Request
+description: Enchancement to xportr functionality
+title: "Feature Request: <Insert Issue Title Here>"
+labels: ["enhancement", "programming"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request! We love keeping xportr fresh!
+  - type: textarea
+    id: feature
+    attributes:
+      label: Feature Idea
+      description: Tell us your idea in as few words as possible
+      placeholder: "`xportr_validate` should do x, y and z"
+    validations:
+      required: true
+  - type: textarea
+    id: input
+    attributes:
+      label: Relevant Input
+      description: Can you provide what the inputs should look like?
+      placeholder: "What should the input look like? REMINDER: no patient level data or company sensitive information should be shared via this open public issue"
+    validations:
+      required: false
+  - type: textarea
+    id: output
+    attributes:
+      label: Relevant Output
+      description: Can you provide what the final output should look like?
+      placeholder: "What should the output look like? REMINDER: no patient level data or company sensitive information should be shared via this open public issue"
+    validations:
+      required: false
+  - type: textarea
+    id: code
+    attributes:
+      label: Reproducible Example/Pseudo Code
+      description: Can you provide a working example or a sketch of how the code should work?
+      placeholder: "We love example code and it will speed up the process! REMINDER: no patient level data or company sensitive information should be shared via this open public issue"
+    validations:
+      required: false


### PR DESCRIPTION
## Closes
 - #106 

## Changes
1. Adds two issue templates based on the issue description. Basically the copy of what `{admiral}` has.

Note: Merging this to main so that it will show up in GitHub as soon as it is merged without us waiting for the dev to main merge.