### PR TITLE
#149 - metadata order column to numeric

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * Fixed bug where character_types were case sensitive. They are now case insensitive.
 * Updated `xportr_type` to make type coercion more explicit.
 * Added function `xportr_metadata()` to explicitly set metadata at the start of a pipeline (#44)
+* Metadata order columns are now coersed to numeric by default in `xportr_order` to prevent character sorting (#149)
 
 ## Documentation
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 * Fixed bug where character_types were case sensitive. They are now case insensitive.
 * Updated `xportr_type` to make type coercion more explicit.
 * Added function `xportr_metadata()` to explicitly set metadata at the start of a pipeline (#44)
-* Metadata order columns are now coersed to numeric by default in `xportr_order` to prevent character sorting (#149)
+* Metadata order columns are now coerced to numeric by default in `xportr_order()` to prevent character sorting (#149)
 
 ## Documentation
 

--- a/R/format.R
+++ b/R/format.R
@@ -28,12 +28,11 @@
 #' )
 #'
 #' adsl <- xportr_format(adsl, metadata)
-xportr_format <- function(
-    .df,
-    metadata = NULL,
-    domain = NULL,
-    verbose = getOption("xportr.length_verbose", "none"),
-    metacore = deprecated()) {
+xportr_format <- function(.df,
+                          metadata = NULL,
+                          domain = NULL,
+                          verbose = getOption("xportr.length_verbose", "none"),
+                          metacore = deprecated()) {
   if (!missing(metacore)) {
     lifecycle::deprecate_warn(
       when = "0.3.0",

--- a/R/label.R
+++ b/R/label.R
@@ -30,12 +30,11 @@
 #' )
 #'
 #' adsl <- xportr_label(adsl, metadata)
-xportr_label <- function(
-    .df,
-    metadata = NULL,
-    domain = NULL,
-    verbose = getOption("xportr.length_verbose", "none"),
-    metacore = deprecated()) {
+xportr_label <- function(.df,
+                         metadata = NULL,
+                         domain = NULL,
+                         verbose = getOption("xportr.length_verbose", "none"),
+                         metacore = deprecated()) {
   if (!missing(metacore)) {
     lifecycle::deprecate_warn(
       when = "0.3.0",

--- a/R/length.R
+++ b/R/length.R
@@ -28,12 +28,11 @@
 #' )
 #'
 #' adsl <- xportr_length(adsl, metadata)
-xportr_length <- function(
-    .df,
-    metadata = NULL,
-    domain = NULL,
-    verbose = getOption("xportr.length_verbose", "none"),
-    metacore = deprecated()) {
+xportr_length <- function(.df,
+                          metadata = NULL,
+                          domain = NULL,
+                          verbose = getOption("xportr.length_verbose", "none"),
+                          metacore = deprecated()) {
   if (!missing(metacore)) {
     lifecycle::deprecate_warn(
       when = "0.3.0",

--- a/R/order.R
+++ b/R/order.R
@@ -25,12 +25,11 @@
 #' )
 #'
 #' adsl <- xportr_order(adsl, metadata)
-xportr_order <- function(
-    .df,
-    metadata = NULL,
-    domain = NULL,
-    verbose = getOption("xportr.length_verbose", "none"),
-    metacore = deprecated()) {
+xportr_order <- function(.df,
+                         metadata = NULL,
+                         domain = NULL,
+                         verbose = getOption("xportr.length_verbose", "none"),
+                         metacore = deprecated()) {
   if (!missing(metacore)) {
     lifecycle::deprecate_warn(
       when = "0.3.0",
@@ -69,6 +68,7 @@ xportr_order <- function(
 
   # Grabs vars from Spec and inputted dataset
   vars_in_spec_ds <- metadata[, c(variable_name, order_name)] %>%
+    mutate(!!sym(order_name) := as.numeric(!!sym(order_name))) %>%
     arrange(!!sym(order_name)) %>%
     extract2(variable_name)
 

--- a/R/type.R
+++ b/R/type.R
@@ -32,12 +32,11 @@
 #' )
 #'
 #' df2 <- xportr_type(.df, metadata, "test")
-xportr_type <- function(
-    .df,
-    metadata = NULL,
-    domain = NULL,
-    verbose = getOption("xportr.length_verbose", "none"),
-    metacore = deprecated()) {
+xportr_type <- function(.df,
+                        metadata = NULL,
+                        domain = NULL,
+                        verbose = getOption("xportr.length_verbose", "none"),
+                        metacore = deprecated()) {
   if (!missing(metacore)) {
     lifecycle::deprecate_warn(
       when = "0.3.0",

--- a/tests/testthat/test-order.R
+++ b/tests/testthat/test-order.R
@@ -137,3 +137,16 @@ test_that("xportr_order: Variable ordering messaging is correct", {
     )
   )
 })
+
+test_that("xportr_order: Metadata order columns are coersed to numeric", {
+  df <- data.frame(c = 1:5, a = "a", d = 5:1, b = LETTERS[1:5])
+  df_meta <- data.frame(
+    dataset = "df",
+    variable = letters[1:4],
+    order = c("1", "2", "11", "90")
+  )
+
+  ordered_df <- xportr_order(df, df_meta)
+
+  expect_equal(names(ordered_df), df_meta$variable)
+})


### PR DESCRIPTION
### Thank you for your Pull Request! 

We have developed a Pull Request template to aid you and our reviewers.  Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the xportr codebase remains robust and consistent.  

### The scope of `{xportr}`

`{xportr}`'s scope is to enable R users to write out submission compliant `xpt` files that can be delivered to a Health Authority or to downstream validation software programs.  We see labels, lengths, types, ordering and formats from a dataset specification object (SDTM and ADaM) as being our primary focus. We also see messaging and warnings to users around applying information from the specification file as a primary focus. Please make sure your Pull Request meets this **scope of {xportr}**. If your Pull Request moves beyond this scope, please get in touch with the `{xportr}` team on [slack](https://pharmaverse.slack.com/archives/C030EB2M4GM) or create an issue to discuss.

Please check off each task box as an acknowledgment that you completed the task. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `devel` branch until you have checked off each task.

### Changes Description

Force metadata order column to numeric. Closes #149 

### Task List

- [x] The spirit of xportr is met in your Pull Request
- [x] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [x] Summary of changes filled out in the above Changes Description.  Can be removed or left blank if changes are minor/self-explanatory.
- [x] Check that your Pull Request is targeting the `devel` branch, Pull Requests to `main` should use the [Release Pull Request Template](https://github.com/atorus-research/xportr/tree/94_pr_template/.github/PULL_REQUEST_TEMPLATE)
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/).  Use `styler` package and functions to style files accordingly.
- [x] Updated relevant unit tests or have written new unit tests. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Unit-Tests) for conventions used in this package.
- [x] Creation/updated relevant roxygen headers and examples. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers) for conventions used in this package.
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [x] Run `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new/updated functions occur on the "Reference" page.
- [x] Update NEWS.md if the changes pertain to a user-facing function (i.e. it has an @export tag) or documentation aimed at users (rather than developers)
- [x] Address any updates needed for vignettes and/or templates
- [x] Link the issue Development Panel so that it closes after successful merging.
- [x] Fix merge conflicts 
- [x] Pat yourself on the back for a job well done!  Much love to your accomplishment!
