### PR TITLE
Suggestions on PR #141

### DIFF
--- a/vignettes/deepdive.Rmd
+++ b/vignettes/deepdive.Rmd
@@ -140,7 +140,7 @@ options(
 
 ## Are we being too verbose?
 
-One final note on `options()`.  4 of the core `{xportr}` functions have the ability to set messaging as `"none", "message", "warn", "stop"`. Setting each of these in all your calls can be a bit repetitive.  You can use `options()` to set these at a higher level and avoid this repitition.
+One final note on `options()`.  4 of the core `{xportr}` functions have the ability to set messaging as `"none", "message", "warn", "stop"`. Setting each of these in all your calls can be a bit repetitive.  You can use `options()` to set these at a higher level and avoid this repetition.
 
 ```{r, eval = FALSE}
 # Default

--- a/vignettes/deepdive.Rmd
+++ b/vignettes/deepdive.Rmd
@@ -145,18 +145,18 @@ One final note on `options()`.  4 of the core `{xportr}` functions have the abil
 ```{r, eval = FALSE}
 # Default
 options(
-    xportr.format_verbose = "none",
-    xportr.label_verbose = "none",
-    xportr.length_verbose = "none",
-    xportr.type_verbose = "none",
+  xportr.format_verbose = "none",
+  xportr.label_verbose = "none",
+  xportr.length_verbose = "none",
+  xportr.type_verbose = "none",
 )
 
 # Will send Warning Message to Console
 options(
-    xportr.format_verbose = "warn",
-    xportr.label_verbose = "warn",
-    xportr.length_verbose = "warn",
-    xportr.type_verbose = "warn",
+  xportr.format_verbose = "warn",
+  xportr.label_verbose = "warn",
+  xportr.length_verbose = "warn",
+  xportr.type_verbose = "warn",
 )
 ```
 
@@ -220,10 +220,11 @@ datatable(
     dom = "Bfrtip",
     columnDefs = list(
       list(
-        width = "10px", 
-        targets = c("order", "length", "format", "type", "dataset", "variable")),
+        width = "10px",
+        targets = c("order", "length", "format", "type", "dataset", "variable")
+      ),
       list(
-        className = "text-left", 
+        className = "text-left",
         targets = c("label")
       )
     ),
@@ -232,11 +233,11 @@ datatable(
   )
 ) %>%
   formatStyle(0,
-    target = "row", 
-    color = "black", 
+    target = "row",
+    color = "black",
     backgroundColor = "white",
     fontWeight = "500",
-    lineHeight = "85%", 
+    lineHeight = "85%",
     textAlign = "center",
     fontSize = ".875em" # same as code
   )

--- a/vignettes/deepdive.Rmd
+++ b/vignettes/deepdive.Rmd
@@ -39,8 +39,7 @@ local({
 ```
 
 ```{css, echo=FALSE}
-# Used to control DT outputs
-
+/* Used to control DT outputs */
 .text-left {
   text-align: left;
 }
@@ -220,16 +219,26 @@ datatable(
   options = list(
     dom = "Bfrtip",
     columnDefs = list(
-      list(width = "10px", targets = c("order", "length", "format", "type", "dataset", "variable")),
-      list(className = "text-left", targets = c("label"))
+      list(
+        width = "10px", 
+        targets = c("order", "length", "format", "type", "dataset", "variable")),
+      list(
+        className = "text-left", 
+        targets = c("label")
+      )
     ),
     searching = FALSE,
     autoWidth = TRUE
   )
 ) %>%
   formatStyle(0,
-    target = "row", color = "black", backgroundColor = "white",
-    fontWeight = "bold", lineHeight = "70%", textAlign = "center"
+    target = "row", 
+    color = "black", 
+    backgroundColor = "white",
+    fontWeight = "500",
+    lineHeight = "85%", 
+    textAlign = "center",
+    fontSize = ".875em" # same as code
   )
 ```
 

--- a/vignettes/xportr.Rmd
+++ b/vignettes/xportr.Rmd
@@ -53,6 +53,31 @@ knitr::knit_hooks$set(output = function(x, options) {
 })
 ```
 
+```{r, include=FALSE}
+datatable_template <- function(input_data) {
+  datatable(
+    input_data, 
+    rownames = FALSE, 
+    options = list(
+      autoWidth = FALSE, 
+      scrollX = TRUE, 
+      pageLength = 5,
+      lengthMenu = c(5, 10, 15, 20)
+    )
+  ) %>%
+    formatStyle(
+      0, 
+      target = "row", 
+      color = "black", 
+      backgroundColor = "white", 
+      fontWeight = "500",
+      lineHeight = "85%",
+      fontSize = ".875em" # same as code
+    )
+}
+```
+
+
 # Getting Started with xportr
 
 The demo will make use of a small `ADSL` data set that is apart of the  [`{admiral}`](https://pharmaverse.github.io/admiral/index.html) package. 
@@ -96,11 +121,7 @@ adsl <- admiral::admiral_adsl
 
 
 ```{r, echo = FALSE}
-DT::datatable(adsl, options = list(
-  autoWidth = FALSE, scrollX = TRUE, pageLength = 5,
-  lengthMenu = c(5, 10, 15, 20)
-)) %>%
-  formatStyle(0, target = "row", color = "black", backgroundColor = "white", fontWeight = "bold")
+datatable_template(adsl)
 ```
 
 **NOTE:** The `ADSL` dataset can be created by using this command `admiral::use_ad_template("adsl")`.
@@ -124,11 +145,7 @@ Below is a quick snapshot of the specification file pertaining to the `ADSL` dat
 var_spec_view <- var_spec %>%
   filter(dataset == "ADSL")
 
-DT::datatable(var_spec_view, options = list(
-  autoWidth = FALSE, scrollX = TRUE, pageLength = 5,
-  lengthMenu = c(5, 10, 15, 20)
-)) %>%
-  formatStyle(0, target = "row", color = "black", backgroundColor = "white", fontWeight = "bold")
+datatable_template(var_spec_view)
 ```
 
 # xportr_type() 
@@ -188,11 +205,7 @@ adsl_order <- xportr_order(adsl, var_spec, domain = "ADSL", verbose = "message")
 ```
 
 ```{r, echo = FALSE}
-DT::datatable(adsl_order, options = list(
-  autoWidth = FALSE, scrollX = TRUE, pageLength = 5,
-  lengthMenu = c(5, 10, 15, 20)
-)) %>%
-  formatStyle(0, target = "row", color = "black", backgroundColor = "white", fontWeight = "bold")
+datatable_template(adsl_order)
 ```
 
 # xportr_format()

--- a/vignettes/xportr.Rmd
+++ b/vignettes/xportr.Rmd
@@ -56,20 +56,20 @@ knitr::knit_hooks$set(output = function(x, options) {
 ```{r, include=FALSE}
 datatable_template <- function(input_data) {
   datatable(
-    input_data, 
-    rownames = FALSE, 
+    input_data,
+    rownames = FALSE,
     options = list(
-      autoWidth = FALSE, 
-      scrollX = TRUE, 
+      autoWidth = FALSE,
+      scrollX = TRUE,
       pageLength = 5,
       lengthMenu = c(5, 10, 15, 20)
     )
   ) %>%
     formatStyle(
-      0, 
-      target = "row", 
-      color = "black", 
-      backgroundColor = "white", 
+      0,
+      target = "row",
+      color = "black",
+      backgroundColor = "white",
       fontWeight = "500",
       lineHeight = "85%",
       fontSize = ".875em" # same as code


### PR DESCRIPTION
Instead of making a bunch of loose suggestions, consider this PR against #141 

* font-weight to `500` instead of bold (middle ground between normal and bold)
* line-height so that there's no overlap in letters
* font-size changed to match `code` size
* removes rownames from datatables on `xportr` vignette
* Corrects spelling error
* Corrects styler error

