### PR TITLE
docs: make some minor document related changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 * Fixed messaging of `xportr_order()`to give better visibility of the number of variables being reordered.
 * Add new argument to `xportr_write()` to allow users to specify how xpt validation checks are handled.
 * Fixed bug where character_types were case sensitive. They are now case insensitive (#77).
-* Updated `xportr_type()` to make type coercion more explicit. 
+* Updated `xportr_type()` to make type coercion more explicit.
 * `xpt_validate` updated to accept iso8601 date formats. (#76)
 * Added function `xportr_metadata()` to explicitly set metadata at the start of a pipeline (#44)
 * Metadata order columns are now coerced to numeric by default in `xportr_order()` to prevent character sorting (#149)
@@ -22,8 +22,7 @@
 * Get Started vignette spruced up. Messages are now displayed and link to Deep Dive vignette (#150)
 * Increase test coverage to 100% (#82)
 
-## Deprecation
-and Breaking Changes
+## Deprecation and Breaking Changes
 
 * The `metacore` argument has been renamed to `metadata` in the following six xportr functions: `xportr_df_label()`, `xportr_format()`, `xportr_label()`, `xportr_length()`, `xportr_order()`, and `xportr_type()`. Please update your code to use the new `metadata` argument in place of `metacore`.
 
@@ -34,9 +33,9 @@ and Breaking Changes
 
 # xportr 0.1.0
 
-Beta release for xportr 
+Beta release for xportr
 
-* Added exported functions `xportr_varnames` and `xportr_tidy_rename` into `dev` folder found on GitHub Repostiory.  Intention to move into packages after CRAN release.
+* Added exported functions `xportr_varnames` and `xportr_tidy_rename` into `dev` folder found on GitHub Repostiory. Intention to move into packages after CRAN release.
 * Fixed xportr_format() bug
 * Using admiral ADSL dataset in examples
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -133,7 +133,7 @@ adsl %>%
   xportr_length(var_spec, "ADSL", verbose = "warn") %>%
   xportr_label(var_spec, "ADSL", verbose = "warn") %>%
   xportr_order(var_spec, "ADSL", verbose = "warn") %>%
-  xportr_format(var_spec, "ADSL", verbose = "warn") %>%
+  xportr_format(var_spec, "ADSL") %>%
   xportr_write("adsl.xpt", label = "Subject-Level Analysis Dataset")
 ```
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -19,7 +19,7 @@ navbar:
       aria-label: slack
 
 reference:
-  - title:  Core xportr functions
+  - title: Core xportr functions
   - contents:
       - xportr_type
       - xportr_length
@@ -40,7 +40,6 @@ reference:
       - var_ord_msg
       - xportr_logger
 
-
   - title: xportr example datasets and specification files
   - contents:
       - adsl
@@ -51,4 +50,3 @@ articles:
     navbar: ~
     contents:
       - deepdive
-

--- a/man/xportr_write.Rd
+++ b/man/xportr_write.Rd
@@ -43,8 +43,9 @@ adsl <- data.frame(
 )
 
 xportr_write(adsl,
-             path = paste0(tempdir(),"/adsl.xpt"),
-             label = "Subject-Level Analysis",
-             strict_checks = FALSE)
+  path = paste0(tempdir(), "/adsl.xpt"),
+  label = "Subject-Level Analysis",
+  strict_checks = FALSE
+)
 
 }

--- a/vignettes/deepdive.Rmd
+++ b/vignettes/deepdive.Rmd
@@ -170,7 +170,7 @@ adsl %>%
   xportr_length(var_spec, "ADSL", "message") %>%
   xportr_label(var_spec, "ADSL", "message") %>%
   xportr_order(var_spec, "ADSL", "message") %>%
-  xportr_format(var_spec, "ADSL", "message") %>%
+  xportr_format(var_spec, "ADSL") %>%
   xportr_write("adsl.xpt", label = "Subject-Level Analysis Dataset")
 ```
 

--- a/vignettes/xportr.Rmd
+++ b/vignettes/xportr.Rmd
@@ -5,7 +5,7 @@ output:
     toc: true
     check_title: TRUE
 vignette: >
-  %\VignetteIndexEntry{xportr}
+  %\VignetteIndexEntry{Getting Started}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
Changes:

- Remove the argument verbose from the xportr_format() function calls in examples
- Removes the warning when trying to build the pkgdown site by having consistent VignetteIndexEntry name for “Getting Started”
- Minor format changes to the NEWS.md
- Lint the _pkgdown configuration