### PR TITLE
Fix lint errors in `devel` that appear with new version of `{lintr}` 📦

### DIFF
--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -116,8 +116,8 @@ test_that("xportr_metadata: Var types coerced as expected and raise messages", {
 
   suppressMessages({
     (
-      df4 <- xportr_metadata(df, meta_example)
-        %>% xportr_type(verbose = "message")
+      df4 <- xportr_metadata(df, meta_example) %>%
+        xportr_type(verbose = "message")
     ) %>%
       expect_message("Variable type\\(s\\) in dataframe don't match metadata: `Subj` and `Val`")
   })
@@ -261,8 +261,10 @@ test_that("xportr_type: date variables are not converted to numeric", {
   adsl_original$RFICDT <- as.Date(adsl_original$RFICDT)
   adsl_original$RFICDTM <- as.POSIXct(adsl_original$RFICDTM)
 
-  expect_message(adsl_xpt2 <- adsl_original %>%
-    xportr_type(metadata), NA)
+  expect_message(
+    adsl_xpt2 <- adsl_original %>% xportr_type(metadata),
+    NA
+  )
 
   attr(adsl_original, "_xportr.df_arg_") <- "adsl_original"
 


### PR DESCRIPTION
@bms63 this will correct the lint problems

### Changes Description

* Corrects lintr errors that appear with new version of the package `lintr 3.1.0`

### Task List

- [x] The spirit of xportr is met in your Pull Request
- [x] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [x] Summary of changes filled out in the above Changes Description.  Can be removed or left blank if changes are minor/self-explanatory.
- [x] Check that your Pull Request is targeting the `devel` branch, Pull Requests to `main` should use the [Release Pull Request Template](https://github.com/atorus-research/xportr/tree/94_pr_template/.github/PULL_REQUEST_TEMPLATE)
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/).  Use `styler` package and functions to style files accordingly.
- [x] Updated relevant unit tests or have written new unit tests. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Unit-Tests) for conventions used in this package.
- [x] Creation/updated relevant roxygen headers and examples. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers) for conventions used in this package.
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [x] Run `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new/updated functions occur on the "Reference" page.
- [x] Update NEWS.md if the changes pertain to a user-facing function (i.e. it has an @export tag) or documentation aimed at users (rather than developers)
- [x] Address any updates needed for vignettes and/or templates
- [x] Link the issue Development Panel so that it closes after successful merging.
- [x] Fix merge conflicts 
- [x] Pat yourself on the back for a job well done!  Much love to your accomplishment!
