### PR TITLE
Hard deprecate the `metacore` argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 ## Deprecation and Breaking Changes
 
 * The `label` argument from the `xportr_write()` function is deprecated in favor of the `metadata` argument. (#179)
+* The `metacore` argument, which was renamed to `metadata` in the following six xportr functions: (`xportr_df_label()`, `xportr_format()`, `xportr_label()`, `xportr_length()`, `xportr_order()`, and `xportr_type()`) in version `0.3.0` with a soft deprecation warning, has now been hard deprecated. Please update your code to use the new `metadata` argument in place of `metacore`.
 
 ## Documentation
 

--- a/R/df_label.R
+++ b/R/df_label.R
@@ -44,12 +44,11 @@ xportr_df_label <- function(.df,
                             domain = NULL,
                             metacore = deprecated()) {
   if (!missing(metacore)) {
-    lifecycle::deprecate_warn(
-      when = "0.3.0",
+    lifecycle::deprecate_stop(
+      when = "0.3.1.9005",
       what = "xportr_df_label(metacore = )",
       with = "xportr_df_label(metadata = )"
     )
-    metadata <- metacore
   }
   domain_name <- getOption("xportr.df_domain_name")
   label_name <- getOption("xportr.df_label")

--- a/R/format.R
+++ b/R/format.R
@@ -46,12 +46,11 @@ xportr_format <- function(.df,
                           domain = NULL,
                           metacore = deprecated()) {
   if (!missing(metacore)) {
-    lifecycle::deprecate_warn(
-      when = "0.3.0",
+    lifecycle::deprecate_stop(
+      when = "0.3.1.9005",
       what = "xportr_format(metacore = )",
       with = "xportr_format(metadata = )"
     )
-    metadata <- metacore
   }
   domain_name <- getOption("xportr.domain_name")
   format_name <- getOption("xportr.format_name")

--- a/R/label.R
+++ b/R/label.R
@@ -62,12 +62,11 @@ xportr_label <- function(.df,
                          verbose = getOption("xportr.label_verbose", "none"),
                          metacore = deprecated()) {
   if (!missing(metacore)) {
-    lifecycle::deprecate_warn(
-      when = "0.3.0",
+    lifecycle::deprecate_stop(
+      when = "0.3.1.9005",
       what = "xportr_label(metacore = )",
       with = "xportr_label(metadata = )"
     )
-    metadata <- metacore
   }
   domain_name <- getOption("xportr.domain_name")
   variable_name <- getOption("xportr.variable_name")

--- a/R/length.R
+++ b/R/length.R
@@ -69,12 +69,11 @@ xportr_length <- function(.df,
                           verbose = getOption("xportr.length_verbose", "none"),
                           metacore = deprecated()) {
   if (!missing(metacore)) {
-    lifecycle::deprecate_warn(
-      when = "0.3.0",
+    lifecycle::deprecate_stop(
+      when = "0.3.1.9005",
       what = "xportr_length(metacore = )",
       with = "xportr_length(metadata = )"
     )
-    metadata <- metacore
   }
   domain_name <- getOption("xportr.domain_name")
   variable_length <- getOption("xportr.length")

--- a/R/order.R
+++ b/R/order.R
@@ -65,12 +65,11 @@ xportr_order <- function(.df,
                          verbose = getOption("xportr.order_verbose", "none"),
                          metacore = deprecated()) {
   if (!missing(metacore)) {
-    lifecycle::deprecate_warn(
-      when = "0.3.0",
+    lifecycle::deprecate_stop(
+      when = "0.3.1.9005",
       what = "xportr_order(metacore = )",
       with = "xportr_order(metadata = )"
     )
-    metadata <- metacore
   }
   domain_name <- getOption("xportr.domain_name")
   order_name <- getOption("xportr.order_name")

--- a/R/type.R
+++ b/R/type.R
@@ -82,12 +82,11 @@ xportr_type <- function(.df,
                         verbose = getOption("xportr.type_verbose", "none"),
                         metacore = deprecated()) {
   if (!missing(metacore)) {
-    lifecycle::deprecate_warn(
-      when = "0.3.0",
+    lifecycle::deprecate_stop(
+      when = "0.3.1.9005",
       what = "xportr_type(metacore = )",
       with = "xportr_type(metadata = )"
     )
-    metadata <- metacore
   }
   # Name of the columns for working with metadata
   domain_name <- getOption("xportr.domain_name")

--- a/tests/testthat/test-depreciation.R
+++ b/tests/testthat/test-depreciation.R
@@ -1,16 +1,12 @@
-test_that("xportr_df_label: deprecated metacore argument still works and gives warning", {
+test_that("xportr_df_label: deprecated metacore gives an error", {
   withr::local_options(lifecycle_verbosity = "quiet")
   df <- data.frame(x = "a", y = "b")
   df_meta <- data.frame(dataset = "df", label = "Label")
 
-  df_spec_labeled_df <- xportr_df_label(df, metacore = df_meta)
-
-  expect_equal(attr(df_spec_labeled_df, "label"), "Label")
-  xportr_df_label(df, metacore = df_meta) %>%
-    lifecycle::expect_deprecated("Please use the `metadata` argument instead.")
+  expect_error(xportr_df_label(df, metacore = df_meta))
 })
 
-test_that("xportr_format: deprecated metacore argument still works and gives warning", {
+test_that("xportr_format: deprecated metacore gives an error", {
   withr::local_options(lifecycle_verbosity = "quiet")
   df <- data.frame(x = 1, y = 2)
   df_meta <- data.frame(
@@ -19,33 +15,19 @@ test_that("xportr_format: deprecated metacore argument still works and gives war
     format = "date9."
   )
 
-  formatted_df <- xportr_format(df, metacore = df_meta)
-
-  expect_equal(attr(formatted_df$x, "format.sas"), "DATE9.")
-  xportr_format(df, metacore = df_meta) %>%
-    lifecycle::expect_deprecated("Please use the `metadata` argument instead.")
+  expect_error(xportr_format(df, metacore = df_meta))
 })
 
-test_that("xportr_label: deprecated metacore argument still works and gives warning", {
+test_that("xportr_label: using the deprecated metacore argument gives an error", {
   withr::local_options(lifecycle_verbosity = "quiet")
 
   df <- data.frame(x = "a", y = "b")
   df_meta <- data.frame(dataset = "df", variable = "x", label = "foo")
 
-  df_labeled_df <- suppressMessages(
-    xportr_label(df, metacore = df_meta)
-  )
-
-  expect_equal(attr(df_labeled_df$x, "label"), "foo")
-
-  # Note that only the deprecated message should be caught (others are ignored)
-  suppressMessages(
-    xportr_label(df, metacore = df_meta) %>%
-      lifecycle::expect_deprecated("Please use the `metadata` argument instead.")
-  )
+  expect_error(xportr_label(df, metacore = df_meta))
 })
 
-test_that("xportr_length: deprecated metacore argument still works and gives warning", {
+test_that("xportr_length: using the deprecated metacore argument gives an error", {
   withr::local_options(lifecycle_verbosity = "quiet")
   df <- data.frame(x = "a", y = "b")
   df_meta <- data.frame(
@@ -55,15 +37,10 @@ test_that("xportr_length: deprecated metacore argument still works and gives war
     length = c(1, 2)
   )
 
-  df_with_width <- xportr_length(df, metacore = df_meta)
-
-  expect_equal(c(x = 1, y = 2), map_dbl(df_with_width, attr, "width"))
-
-  xportr_length(df, metacore = df_meta) %>%
-    lifecycle::expect_deprecated("Please use the `metadata` argument instead.")
+  expect_error(xportr_length(df, metacore = df_meta))
 })
 
-test_that("xportr_order: deprecated metacore argument still works and gives warning", {
+test_that("xportr_order: using the deprecated metacore argument gives an error", {
   withr::local_options(lifecycle_verbosity = "quiet")
 
   df <- data.frame(c = 1:5, a = "a", d = 5:1, b = LETTERS[1:5])
@@ -73,20 +50,10 @@ test_that("xportr_order: deprecated metacore argument still works and gives warn
     order = 1:4
   )
 
-  ordered_df <- suppressMessages(
-    xportr_order(df, metacore = df_meta, domain = "DOMAIN")
-  )
-
-  expect_equal(names(ordered_df), df_meta$variable)
-
-  # Note that only the deprecated message should be caught (others are ignored)
-  suppressMessages(
-    xportr_order(df, metacore = df_meta) %>%
-      lifecycle::expect_deprecated("Please use the `metadata` argument instead.")
-  )
+  expect_error(xportr_order(df, metacore = df_meta, domain = "DOMAIN"))
 })
 
-test_that("xportr_type: deprecated metacore argument still works and gives warning", {
+test_that("xportr_type: using the deprecated metacore argument gives an error", {
   withr::local_options(lifecycle_verbosity = "quiet")
   df <- data.frame(
     Subj = as.character(c(123, 456, 789, "", NA, NA_integer_)),
@@ -101,13 +68,5 @@ test_that("xportr_type: deprecated metacore argument still works and gives warni
     format = NA
   )
 
-  df2 <- suppressMessages(
-    xportr_type(df, metacore = df_meta)
-  )
-
-  # Note that only the deprecated message should be caught (others are ignored)
-  suppressMessages(
-    xportr_type(df, metacore = df_meta) %>%
-      lifecycle::expect_deprecated("Please use the `metadata` argument instead.")
-  )
+  expect_error(xportr_type(df, metacore = df_meta))
 })

--- a/tests/testthat/test-length.R
+++ b/tests/testthat/test-length.R
@@ -181,7 +181,6 @@ test_that("xportr_length: Metacore instance can be used", {
 })
 
 test_that("xportr_length: Domain not in character format", {
-  skip_if_not_installed("haven")
   skip_if_not_installed("readxl")
 
   require(haven, quietly = TRUE)

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -547,6 +547,7 @@ test_that("xportr_length: Expect error if domain is not a character", {
 # tests for `xportr_metadata()` basic functionality
 # start
 test_that("xportr_metadata: Check metadata interaction with other functions", {
+  skip_if_not_installed("admiral")
   adsl <- admiral::admiral_adsl
 
   var_spec <-

--- a/tests/testthat/test-order.R
+++ b/tests/testthat/test-order.R
@@ -110,7 +110,6 @@ test_that("xportr_order: error when metadata is not set", {
 })
 
 test_that("xportr_order: Variable ordering messaging is correct", {
-  skip_if_not_installed("haven")
   skip_if_not_installed("readxl")
 
   require(haven, quietly = TRUE)


### PR DESCRIPTION
### Changes Description

The use of `metacore` argument will now throw an error instead of a warning message.

### Task List

- [x] The spirit of xportr is met in your Pull Request
- [x] Place Closes #203 into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [x] Summary of changes filled out in the above Changes Description. Can be removed or left blank if changes are minor/self-explanatory.
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/). Use `styler` package and functions to style files accordingly.
- [x] Updated relevant unit tests or have written new unit tests. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Unit-Tests) for conventions used in this package.
- [x] Creation/updated relevant roxygen headers and examples. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers) for conventions used in this package.
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [x] Run `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new/updated functions occur on the "Reference" page.
- [x] Update NEWS.md if the changes pertain to a user-facing function (i.e. it has an @export tag) or documentation aimed at users (rather than developers)
- [x] Make sure that the pacakge version in the NEWS.md and DESCRIPTION file is same. Don't worry about updating the version because it will be auto-updated using the `vbump.yaml` CI.
- [x] Address any updates needed for vignettes and/or templates
- [x] Link the issue Development Panel so that it closes after successful merging.
- [x] Fix merge conflicts
- [x] Pat yourself on the back for a job well done! Much love to your accomplishment!
