### PR TITLE
Closes #161 Coercion date datatype

### DIFF
--- a/R/type.R
+++ b/R/type.R
@@ -93,6 +93,8 @@ xportr_type <- function(.df,
   variable_name <- getOption("xportr.variable_name")
   type_name <- getOption("xportr.type_name")
   characterTypes <- c(getOption("xportr.character_types"), "_character")
+  characterMetadataTypes <- c(getOption("xportr.character_metadata_types"), "_character")
+  numericMetadataTypes <- c(getOption("xportr.numeric_metadata_types"), "_numeric")
   numericTypes <- c(getOption("xportr.numeric_types"), "_numeric")
   format_name <- getOption("xportr.format_name")
 
@@ -137,14 +139,14 @@ xportr_type <- function(.df,
       # _character is used here as a mask of character, in case someone doesn't
       # want 'character' coerced to character
       type.x = if_else(type.x %in% characterTypes, "_character", type.x),
-      type.x = if_else(type.x %in% numericTypes | (grepl("DT$|DTM$|TM$", variable) & !is.na(format)),
+      type.x = if_else(type.x %in% numericTypes,
         "_numeric",
         type.x
       ),
       type.y = if_else(is.na(type.y), type.x, type.y),
       type.y = tolower(type.y),
-      type.y = if_else(type.y %in% characterTypes | (grepl("DTC$", variable) & is.na(format)), "_character", type.y),
-      type.y = if_else(type.y %in% numericTypes, "_numeric", type.y)
+      type.y = if_else(type.y %in% characterMetadataTypes, "_character", type.y),
+      type.y = if_else(type.y %in% numericMetadataTypes, "_numeric", type.y)
     )
 
   # It is possible that a variable exists in the table that isn't in the metadata

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -13,14 +13,16 @@
     xportr.label_verbose = "none",
     xportr.length_verbose = "none",
     xportr.type_verbose = "none",
-    xportr.character_types = c(
+    xportr.character_types = c("character"),
+    xportr.character_metadata_types = c(
       "character", "char", "text", "date", "posixct",
       "posixt", "datetime", "time", "partialdate",
       "partialtime", "partialdatetime",
       "incompletedatetime", "durationdatetime",
       "intervaldatetime"
     ),
-    xportr.numeric_types = c("integer", "numeric", "num", "float"),
+    xportr.numeric_metadata_types = c("integer", "numeric", "num", "float"),
+    xportr.numeric_types = c("integer", "float", "posixct", "posixt", "time", "date"),
     xportr.order_name = "order"
   )
   toset <- !(names(op.devtools) %in% names(op))


### PR DESCRIPTION
### Thank you for your Pull Request!

We have developed a Pull Request template to aid you and our reviewers. Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the xportr codebase remains robust and consistent.

### The scope of `{xportr}`

`{xportr}`'s scope is to enable R users to write out submission compliant `xpt` files that can be delivered to a Health Authority or to downstream validation software programs. We see labels, lengths, types, ordering and formats from a dataset specification object (SDTM and ADaM) as being our primary focus. We also see messaging and warnings to users around applying information from the specification file as a primary focus. Please make sure your Pull Request meets this **scope of {xportr}**. If your Pull Request moves beyond this scope, please get in touch with the `{xportr}` team on [slack](https://pharmaverse.slack.com/archives/C030EB2M4GM) or create an issue to discuss.

Please check off each task box as an acknowledgment that you completed the task. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `devel` branch until you have checked off each task.

### Changes Description

_(descriptions of changes)_

### Task List

- [ ] The spirit of xportr is met in your Pull Request
- [ ] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [ ] Summary of changes filled out in the above Changes Description. Can be removed or left blank if changes are minor/self-explanatory.
- [ ] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/). Use `styler` package and functions to style files accordingly.
- [ ] Updated relevant unit tests or have written new unit tests. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Unit-Tests) for conventions used in this package.
- [ ] Creation/updated relevant roxygen headers and examples. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers) for conventions used in this package.
- [ ] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [ ] Run `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new/updated functions occur on the "Reference" page.
- [ ] Update NEWS.md if the changes pertain to a user-facing function (i.e. it has an @export tag) or documentation aimed at users (rather than developers)
- [ ] Make sure that the pacakge version in the NEWS.md and DESCRIPTION file is same. Don't worry about updating the version because it will be auto-updated using the `vbump.yaml` CI.
- [ ] Address any updates needed for vignettes and/or templates
- [ ] Link the issue Development Panel so that it closes after successful merging.
- [ ] Fix merge conflicts
- [ ] Pat yourself on the back for a job well done! Much love to your accomplishment!
