### PR TITLE
Closes #226 - `metadata` is no longer inferred on `xportr_write`

### DIFF
--- a/R/write.R
+++ b/R/write.R
@@ -12,7 +12,8 @@
 #' @param strict_checks If TRUE, xpt validation will report errors and not write
 #'   out the dataset. If FALSE, xpt validation will report warnings and continue
 #'   with writing out the dataset. Defaults to FALSE
-#' @inheritParams xportr_length
+#' @inheritParams xportr_df_label
+#' @inheritSection xportr_df_label Metadata
 #'
 #' @details
 #'   * Variable and dataset labels are stored in the "label" attribute.
@@ -67,7 +68,8 @@ xportr_write <- function(.df,
   domain <- domain %||% attr(.df, "_xportr.df_arg_")
   if (!is.null(domain)) attr(.df, "_xportr.df_arg_") <- domain
 
-  metadata <- metadata %||% attr(.df, "_xportr.df_metadata_")
+  # metadata should not be inferred from the data frame if it is not provided
+  # by the user.
 
   ## End of common section
 

--- a/man/xportr_write.Rd
+++ b/man/xportr_write.Rd
@@ -19,8 +19,8 @@ xportr_write(
 \item{path}{Path where transport file will be written. File name sans will be
 used as \code{xpt} name.}
 
-\item{metadata}{A data frame containing variable level metadata. See
-'Metadata' section for details.}
+\item{metadata}{A data frame containing dataset. See 'Metadata' section for
+details.}
 
 \item{domain}{Appropriate CDSIC dataset name, e.g. ADAE, DM. Used to subset
 the metadata object. If none is passed, then  \code{\link[=xportr_metadata]{xportr_metadata()}} must be
@@ -49,6 +49,22 @@ to the FDA.
 \item SAS type are stored in the "SAStype" attribute.
 }
 }
+\section{Metadata}{
+ The argument passed in the 'metadata' argument can either
+be a metacore object, or a data.frame containing the data listed below. If
+metacore is used, no changes to options are required.
+
+For data.frame 'metadata' arguments two columns must be present:
+\enumerate{
+\item Domain Name - passed as the 'xportr.df_domain_name' option. Default:
+"dataset". This is the column subset by the 'domain' argument in the
+function.
+\item Label Name - passed as the 'xportr.df_label' option. Default:
+"label". Character values to update the 'label' attribute of the
+dataframe This is passed to \code{haven::write_xpt} to note the label.
+}
+}
+
 \examples{
 adsl <- data.frame(
   SUBL = as.character(123, 456, 789),


### PR DESCRIPTION
### Thank you for your Pull Request!

We have developed a Pull Request template to aid you and our reviewers. Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the xportr codebase remains robust and consistent.

### The scope of `{xportr}`

`{xportr}`'s scope is to enable R users to write out submission compliant `xpt` files that can be delivered to a Health Authority or to downstream validation software programs. We see labels, lengths, types, ordering and formats from a dataset specification object (SDTM and ADaM) as being our primary focus. We also see messaging and warnings to users around applying information from the specification file as a primary focus. Please make sure your Pull Request meets this **scope of {xportr}**. If your Pull Request moves beyond this scope, please get in touch with the `{xportr}` team on [slack](https://pharmaverse.slack.com/archives/C030EB2M4GM) or create an issue to discuss.

Please check off each task box as an acknowledgment that you completed the task. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `devel` branch until you have checked off each task.

### Changes Description

- Closes #226 
- Revert change in #190
  - `xportr_write` didn't infer `metadata` parameter from data_frame (this behavior is restored with this PR)

### Task List

- [x] The spirit of xportr is met in your Pull Request
- [x] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [x] Summary of changes filled out in the above Changes Description. Can be removed or left blank if changes are minor/self-explanatory.
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/). Use `styler` package and functions to style files accordingly.
- [x] Updated relevant unit tests or have written new unit tests. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Unit-Tests) for conventions used in this package.
- [x] Creation/updated relevant roxygen headers and examples. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers) for conventions used in this package.
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [x] Run `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new/updated functions occur on the "Reference" page.
- [x] Update NEWS.md if the changes pertain to a user-facing function (i.e. it has an @export tag) or documentation aimed at users (rather than developers)
- [x] Make sure that the package version in the NEWS.md and DESCRIPTION file is same. Don't worry about updating the version because it will be auto-updated using the `vbump.yaml` CI.
- [x] Address any updates needed for vignettes and/or templates
- [x] Link the issue Development Panel so that it closes after successful merging.
- [x] Fix merge conflicts
- [x] Pat yourself on the back for a job well done! Much love to your accomplishment!
