### PR TITLE
Use selection helpers during variable based selection

### DIFF
--- a/R/length.R
+++ b/R/length.R
@@ -162,11 +162,10 @@ xportr_length <- function(.df,
         length_meta = as.numeric(length_msg[[paste0(variable_length, ".y")]])
       ) %>%
       filter(length_df < length_meta) %>%
-      select(variable_name, length_df, length_meta)
+      select(all_of(variable_name), length_df, length_meta)
 
     max_length_msg(length_msg, verbose)
   }
-
 
   .df
 }


### PR DESCRIPTION
Closes #247 

The warning from the issue indicates we should start using the [selection helpers](https://tidyselect.r-lib.org/reference/all_of.html) to select from a variable. So this adds the `all_of()` to eliminate the warning.