### PR TITLE
Closes #215, #222: add `xportr()` and more details about length to deepdive

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -60,6 +60,8 @@ done to make the use of xportr functions more explicit. (#182)
 
 * Removed non-user facing function documentation (#192)
 
+* Added more details about `xportr_length()` and `xportr()` to deep dive vignette (#215, #222)
+
 ## Miscellaneous
 
 * Tests use `{withr}` to create temporary files that are automatically deleted (#219)

--- a/vignettes/deepdive.Rmd
+++ b/vignettes/deepdive.Rmd
@@ -307,6 +307,15 @@ adsl_type <- xportr_type(.df = adsl_fct, metadata = var_spec, domain = "ADSL", v
 
 ## `xportr_length()`
 
+There are two sources of length (data-driven and spec-driven):
+
+- Data-driven length: max length for character columns and 8 for other data types
+
+- Spec-driven length: from the metadata
+
+1. Users can either specify the length in the metadata or leave it blank for data-driven length.
+2. When the length is missing in the metadata, the data-driven length will be applied. 
+
 Next we will use `xportr_length()` to apply the length column of the _metadata object_ to the `ADSL` dataset. Using the `str()` function we have displayed all the variables with their attributes.  You can see that each variable has a label, but there is no information on the lengths of the variable. 
 
 ```{r, max.height='300px', attr.output='.numberLines', echo = FALSE}
@@ -479,6 +488,31 @@ ADSL %>%
   xportr_write(path = "adsl.xpt", strict_checks = TRUE)
 ```
 
+## `xportr()`
+Too many functions to call? Simplify with `xportr()`. It bundles all core `xportr` functions for writing to `xpt`.
+```{r, echo = TRUE, error = TRUE}
+xportr(
+  ADSL,
+  var_metadata = var_spec,
+  df_metadata = dataset_spec,
+  domain = "ADSL",
+  verbose = "none",
+  path = "adsl.xpt"
+)
+```
+
+`xportr()` is equivalent to calling the following functions individually:    
+```{r, echo = TRUE, error = TRUE}
+ADSL %>%
+  xportr_metadata(var_spec, "ADSL") %>%
+  xportr_type() %>%
+  xportr_length(length_source = "metadata") %>%
+  xportr_label() %>%
+  xportr_order() %>%
+  xportr_format() %>%
+  xportr_df_label(dataset_spec) %>%
+  xportr_write(path = "adsl.xpt", strict_checks = FALSE)
+```
 
 ## Future Work
 


### PR DESCRIPTION
### Thank you for your Pull Request!

We have developed a Pull Request template to aid you and our reviewers. Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the xportr codebase remains robust and consistent.

### The scope of `{xportr}`

`{xportr}`'s scope is to enable R users to write out submission compliant `xpt` files that can be delivered to a Health Authority or to downstream validation software programs. We see labels, lengths, types, ordering and formats from a dataset specification object (SDTM and ADaM) as being our primary focus. We also see messaging and warnings to users around applying information from the specification file as a primary focus. Please make sure your Pull Request meets this **scope of {xportr}**. If your Pull Request moves beyond this scope, please get in touch with the `{xportr}` team on [slack](https://pharmaverse.slack.com/archives/C030EB2M4GM) or create an issue to discuss.

Please check off each task box as an acknowledgment that you completed the task. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `main` branch until you have checked off each task.

### Changes Description

_(descriptions of changes)_

### Task List

- [ ] The spirit of xportr is met in your Pull Request
- [ ] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [ ] Summary of changes filled out in the above Changes Description. Can be removed or left blank if changes are minor/self-explanatory.
- [ ] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/). Use `styler` package and functions to style files accordingly.
- [ ] New functions or arguments follow established convention found in the [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers).
- [ ] Updated relevant unit tests or have written new unit tests. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Unit-Tests) for conventions used in this package.
- [ ] Creation/updated relevant roxygen headers and examples. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers) for conventions used in this package.
- [ ] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [ ] Run `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new/updated functions occur on the "Reference" page.
- [ ] Update `NEWS.md` if the changes pertain to a user-facing function (i.e. it has an `@export` tag) or documentation aimed at users (rather than developers)
- [ ] The `NEWS.md` entry should go under the `# xportr development version` section. Don't worry about updating the version because it will be auto-updated using the `vbump.yaml` CI.
- [ ] Address any updates needed for vignettes and/or templates.
- [ ] Link the issue Development Panel so that it closes after successful merging.
- [ ] The developer is responsible for fixing merge conflicts not the Reviewer.
- [ ] Pat yourself on the back for a job well done! Much love to your accomplishment!
