### PR TITLE
Specify domain filtering uses environment domain variable

### DIFF
--- a/R/df_label.R
+++ b/R/df_label.R
@@ -70,7 +70,7 @@ xportr_df_label <- function(.df,
   if (inherits(metadata, "Metacore")) metadata <- metadata$ds_spec
 
   label <- metadata %>%
-    filter(!!sym(domain_name) == domain) %>%
+    filter(!!sym(domain_name) == .env$domain) %>%
     select(!!sym(label_name)) %>%
     # If a dataframe is used this will also be a dataframe, change to character.
     as.character()

--- a/R/format.R
+++ b/R/format.R
@@ -74,7 +74,7 @@ xportr_format <- function(.df,
 
   if (domain_name %in% names(metadata) && !is.null(domain)) {
     metadata <- metadata %>%
-      dplyr::filter(!!sym(domain_name) == domain & !is.na(!!sym(format_name)))
+      dplyr::filter(!!sym(domain_name) == .env$domain & !is.na(!!sym(format_name)))
   } else {
     # Common check for multiple variables name
     check_multiple_var_specs(metadata, variable_name)

--- a/R/label.R
+++ b/R/label.R
@@ -97,7 +97,7 @@ xportr_label <- function(.df,
 
   if (domain_name %in% names(metadata) && !is.null(domain)) {
     metadata <- metadata %>%
-      dplyr::filter(!!sym(domain_name) == domain)
+      dplyr::filter(!!sym(domain_name) == .env$domain)
   } else {
     # Common check for multiple variables name
     check_multiple_var_specs(metadata, variable_name)

--- a/R/length.R
+++ b/R/length.R
@@ -98,7 +98,7 @@ xportr_length <- function(.df,
 
   if (domain_name %in% names(metadata) && !is.null(domain)) {
     metadata <- metadata %>%
-      filter(!!sym(domain_name) == domain)
+      filter(!!sym(domain_name) == .env$domain)
   } else {
     # Common check for multiple variables name
     check_multiple_var_specs(metadata, variable_name)

--- a/R/order.R
+++ b/R/order.R
@@ -100,7 +100,7 @@ xportr_order <- function(.df,
 
   if (domain_name %in% names(metadata) && !is.null(domain)) {
     metadata <- metadata %>%
-      dplyr::filter(!!sym(domain_name) == domain & !is.na(!!sym(order_name)))
+      dplyr::filter(!!sym(domain_name) == .env$domain & !is.na(!!sym(order_name)))
   } else {
     metadata <- metadata %>%
       dplyr::filter(!is.na(!!sym(order_name)))

--- a/R/type.R
+++ b/R/type.R
@@ -122,7 +122,7 @@ xportr_type <- function(.df,
 
   if (domain_name %in% names(metadata) && !is.null(domain)) {
     metadata <- metadata %>%
-      filter(!!sym(domain_name) == domain)
+      filter(!!sym(domain_name) == .env$domain)
   }
 
   metacore <- metadata %>%


### PR DESCRIPTION
### Thank you for your Pull Request!

We have developed a Pull Request template to aid you and our reviewers. Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the xportr codebase remains robust and consistent.

### The scope of `{xportr}`

`{xportr}`'s scope is to enable R users to write out submission compliant `xpt` files that can be delivered to a Health Authority or to downstream validation software programs. We see labels, lengths, types, ordering and formats from a dataset specification object (SDTM and ADaM) as being our primary focus. We also see messaging and warnings to users around applying information from the specification file as a primary focus. Please make sure your Pull Request meets this **scope of {xportr}**. If your Pull Request moves beyond this scope, please get in touch with the `{xportr}` team on [slack](https://pharmaverse.slack.com/archives/C030EB2M4GM) or create an issue to discuss.

Please check off each task box as an acknowledgment that you completed the task. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `main` branch until you have checked off each task.

### Changes Description

Closes #137 

Specify domain filtering uses environment variable

### Task List

- [ ] The spirit of xportr is met in your Pull Request
- [ ] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [ ] Summary of changes filled out in the above Changes Description. Can be removed or left blank if changes are minor/self-explanatory.
- [ ] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/). Use `styler` package and functions to style files accordingly.
- [ ] New functions or arguments follow established convention found in the [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers).
- [ ] Updated relevant unit tests or have written new unit tests. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Unit-Tests) for conventions used in this package.
- [ ] Creation/updated relevant roxygen headers and examples. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers) for conventions used in this package.
- [ ] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [ ] Run `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new/updated functions occur on the "Reference" page.
- [ ] Update `NEWS.md` if the changes pertain to a user-facing function (i.e. it has an `@export` tag) or documentation aimed at users (rather than developers)
- [ ] The `NEWS.md` entry should go under the `# xportr development version` section. Don't worry about updating the version because it will be auto-updated using the `vbump.yaml` CI.
- [ ] Address any updates needed for vignettes and/or templates.
- [ ] Link the issue Development Panel so that it closes after successful merging.
- [ ] The developer is responsible for fixing merge conflicts not the Reviewer.
- [ ] Pat yourself on the back for a job well done! Much love to your accomplishment!
