### PR TITLE
Doc updates per #261

### DIFF
--- a/R/split.R
+++ b/R/split.R
@@ -21,15 +21,13 @@
 #' @export
 #'
 #' @examples
-#' data("adsl_xportr")
-#' adsl <- adsl_xportr
 #'
 #' adlb <- data.frame(
 #'   USUBJID = c(1001, 1002, 1003),
 #'   LBCAT = c("HEMATOLOGY", "HEMATOLOGY", "CHEMISTRY")
 #' )
 #'
-#' adsl <- xportr_split(adsl, "LBCAT")
+#' adlb <- xportr_split(adlb, "LBCAT")
 xportr_split <- function(.df, split_by = NULL) {
   attr(.df, "_xportr.split_by_") <- split_by
 

--- a/R/xportr-package.R
+++ b/R/xportr-package.R
@@ -127,7 +127,7 @@ globalVariables(c(
   "abbr_parsed", "abbr_stem", "adj_orig", "adj_parsed", "col_pos", "dict_varname",
   "lower_original_varname", "my_minlength", "num_st_ind", "original_varname",
   "renamed_n", "renamed_var", "use_bundle", "viable_start", "type.x", "type.y",
-  "variable", "length.x", "lenght.y", "e", "length_df", "length_meta"
+  "variable", "length.x", "lenght.y", "e", "length_df", "length_meta", ".env"
 ))
 
 # The following block is used by usethis to automatically manage

--- a/R/xportr.R
+++ b/R/xportr.R
@@ -3,8 +3,7 @@
 #' @param .df A data frame of CDISC standard.
 #' @param var_metadata A data frame containing variable level metadata
 #' @param domain Appropriate CDISC dataset name, e.g. ADAE, DM. Used to subset
-#'   the metadata object. If none is passed, then name of the dataset passed as
-#'   .df will be used.
+#'   the metadata object.
 #' @param verbose The action this function takes when an action is taken on the
 #'   dataset or function validation finds an issue. See 'Messaging' section for
 #'   details. Options are 'stop', 'warn', 'message', and 'none'

--- a/man/metadata.Rd
+++ b/man/metadata.Rd
@@ -13,8 +13,7 @@ xportr_metadata(.df, metadata = NULL, domain = NULL, verbose = NULL)
 'Metadata' section for details.}
 
 \item{domain}{Appropriate CDISC dataset name, e.g. ADAE, DM. Used to subset
-the metadata object. If none is passed, then name of the dataset passed as
-.df will be used.}
+the metadata object.}
 
 \item{verbose}{The action this function takes when an action is taken on the
 dataset or function validation finds an issue. See 'Messaging' section for

--- a/man/xportr.Rd
+++ b/man/xportr.Rd
@@ -22,8 +22,7 @@ xportr(
 \item{df_metadata}{A data frame containing dataset level metadata.}
 
 \item{domain}{Appropriate CDISC dataset name, e.g. ADAE, DM. Used to subset
-the metadata object. If none is passed, then name of the dataset passed as
-.df will be used.}
+the metadata object.}
 
 \item{verbose}{The action this function takes when an action is taken on the
 dataset or function validation finds an issue. See 'Messaging' section for

--- a/man/xportr_df_label.Rd
+++ b/man/xportr_df_label.Rd
@@ -13,8 +13,7 @@ xportr_df_label(.df, metadata = NULL, domain = NULL, metacore = deprecated())
 details.}
 
 \item{domain}{Appropriate CDISC dataset name, e.g. ADAE, DM. Used to subset
-the metadata object. If none is passed, then name of the dataset passed as
-.df will be used.}
+the metadata object.}
 
 \item{metacore}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Previously used to pass
 metadata now renamed with \code{metadata}}

--- a/man/xportr_format.Rd
+++ b/man/xportr_format.Rd
@@ -19,8 +19,7 @@ xportr_format(
 'Metadata' section for details.}
 
 \item{domain}{Appropriate CDISC dataset name, e.g. ADAE, DM. Used to subset
-the metadata object. If none is passed, then name of the dataset passed as
-.df will be used.}
+the metadata object.}
 
 \item{verbose}{The action this function takes when an action is taken on the
 dataset or function validation finds an issue. See 'Messaging' section for

--- a/man/xportr_label.Rd
+++ b/man/xportr_label.Rd
@@ -19,8 +19,7 @@ xportr_label(
 'Metadata' section for details.}
 
 \item{domain}{Appropriate CDISC dataset name, e.g. ADAE, DM. Used to subset
-the metadata object. If none is passed, then name of the dataset passed as
-.df will be used.}
+the metadata object.}
 
 \item{verbose}{The action this function takes when an action is taken on the
 dataset or function validation finds an issue. See 'Messaging' section for

--- a/man/xportr_length.Rd
+++ b/man/xportr_length.Rd
@@ -20,8 +20,7 @@ xportr_length(
 'Metadata' section for details.}
 
 \item{domain}{Appropriate CDISC dataset name, e.g. ADAE, DM. Used to subset
-the metadata object. If none is passed, then name of the dataset passed as
-.df will be used.}
+the metadata object.}
 
 \item{verbose}{The action this function takes when an action is taken on the
 dataset or function validation finds an issue. See 'Messaging' section for

--- a/man/xportr_order.Rd
+++ b/man/xportr_order.Rd
@@ -19,8 +19,7 @@ xportr_order(
 'Metadata' section for details.}
 
 \item{domain}{Appropriate CDISC dataset name, e.g. ADAE, DM. Used to subset
-the metadata object. If none is passed, then name of the dataset passed as
-.df will be used.}
+the metadata object.}
 
 \item{verbose}{The action this function takes when an action is taken on the
 dataset or function validation finds an issue. See 'Messaging' section for

--- a/man/xportr_split.Rd
+++ b/man/xportr_split.Rd
@@ -29,13 +29,11 @@ with a number for uniqueness. These files should be noted in the Reviewer Guides
 CDISC guidance to note how you split your files.
 }
 \examples{
-data("adsl_xportr")
-adsl <- adsl_xportr
 
 adlb <- data.frame(
   USUBJID = c(1001, 1002, 1003),
   LBCAT = c("HEMATOLOGY", "HEMATOLOGY", "CHEMISTRY")
 )
 
-adsl <- xportr_split(adsl, "LBCAT")
+adlb <- xportr_split(adlb, "LBCAT")
 }

--- a/man/xportr_type.Rd
+++ b/man/xportr_type.Rd
@@ -19,8 +19,7 @@ xportr_type(
 'Metadata' section for details.}
 
 \item{domain}{Appropriate CDISC dataset name, e.g. ADAE, DM. Used to subset
-the metadata object. If none is passed, then name of the dataset passed as
-.df will be used.}
+the metadata object.}
 
 \item{verbose}{The action this function takes when an action is taken on the
 dataset or function validation finds an issue. See 'Messaging' section for

--- a/man/xportr_write.Rd
+++ b/man/xportr_write.Rd
@@ -23,8 +23,7 @@ used as \code{xpt} name.}
 details.}
 
 \item{domain}{Appropriate CDISC dataset name, e.g. ADAE, DM. Used to subset
-the metadata object. If none is passed, then name of the dataset passed as
-.df will be used.}
+the metadata object.}
 
 \item{strict_checks}{If TRUE, xpt validation will report errors and not write
 out the dataset. If FALSE, xpt validation will report warnings and continue


### PR DESCRIPTION
### Thank you for your Pull Request!

We have developed a Pull Request template to aid you and our reviewers. Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the xportr codebase remains robust and consistent.

### The scope of `{xportr}`

`{xportr}`'s scope is to enable R users to write out submission compliant `xpt` files that can be delivered to a Health Authority or to downstream validation software programs. We see labels, lengths, types, ordering and formats from a dataset specification object (SDTM and ADaM) as being our primary focus. We also see messaging and warnings to users around applying information from the specification file as a primary focus. Please make sure your Pull Request meets this **scope of {xportr}**. If your Pull Request moves beyond this scope, please get in touch with the `{xportr}` team on [slack](https://pharmaverse.slack.com/archives/C030EB2M4GM) or create an issue to discuss.

Please check off each task box as an acknowledgment that you completed the task. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `main` branch until you have checked off each task.

### Changes Description

This closes #261 

### Task List

- [x] The spirit of xportr is met in your Pull Request
- [x] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [x] Summary of changes filled out in the above Changes Description. Can be removed or left blank if changes are minor/self-explanatory.
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/). Use `styler` package and functions to style files accordingly.
- [x] New functions or arguments follow established convention found in the [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers).
- [x] Updated relevant unit tests or have written new unit tests. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Unit-Tests) for conventions used in this package.
- [x] Creation/updated relevant roxygen headers and examples. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers) for conventions used in this package.
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [x] Run `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new/updated functions occur on the "Reference" page.
- [x] Update `NEWS.md` if the changes pertain to a user-facing function (i.e. it has an `@export` tag) or documentation aimed at users (rather than developers)
- [x] The `NEWS.md` entry should go under the `# xportr development version` section. Don't worry about updating the version because it will be auto-updated using the `vbump.yaml` CI.
- [x] Address any updates needed for vignettes and/or templates.
- [x] Link the issue Development Panel so that it closes after successful merging.
- [x] The developer is responsible for fixing merge conflicts not the Reviewer.
- [x] Pat yourself on the back for a job well done! Much love to your accomplishment!
