### PR TITLE
Closes #275

### DIFF
--- a/R/type.R
+++ b/R/type.R
@@ -117,7 +117,7 @@ xportr_type <- function(.df,
   }
 
   metacore <- metadata %>%
-    select(!!sym(variable_name), !!sym(type_name))
+    select(variable = !!sym(variable_name), type = !!sym(type_name))
 
   # Common check for multiple variables name
   check_multiple_var_specs(metadata, variable_name)
@@ -128,7 +128,7 @@ xportr_type <- function(.df,
   # Produces a data.frame with Variables, Type.x(Table), and Type.y(metadata)
   meta_ordered <- left_join(
     data.frame(variable = names(.df), type = unlist(table_cols_types)),
-    metadata,
+    metacore,
     by = "variable"
   ) %>%
     mutate(

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -325,3 +325,24 @@ test_that("type Test 11: Works as expected with only one domain in metadata", {
 
   expect_equal(xportr_type(adsl, metadata), adsl)
 })
+
+# xportr_type ----
+## Test 12: xportr_type: xportr_options() overrides work properly ----
+test_that("type Test 12: xportr_options() overrides work properly", {
+  op <- options()
+
+  data("adsl_xportr", "var_spec", package = "xportr")
+  var_spec <- distinct(var_spec, Variable, .keep_all = TRUE) # quick fix because there's dups in the data
+
+  xportr_options(
+    xportr.variable_name = "Variable",
+    xportr.type_name = "Data Type"
+  )
+
+  expect_silent(
+    adsl_xportr %>% xportr_type(var_spec, "ADSL", "message")
+  )
+
+  options(op)
+})
+

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -345,4 +345,3 @@ test_that("type Test 12: xportr_options() overrides work properly", {
 
   options(op)
 })
-


### PR DESCRIPTION
### Thank you for your Pull Request!

We have developed a Pull Request template to aid you and our reviewers. Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the xportr codebase remains robust and consistent.

### The scope of `{xportr}`

`{xportr}`'s scope is to enable R users to write out submission compliant `xpt` files that can be delivered to a Health Authority or to downstream validation software programs. We see labels, lengths, types, ordering and formats from a dataset specification object (SDTM and ADaM) as being our primary focus. We also see messaging and warnings to users around applying information from the specification file as a primary focus. Please make sure your Pull Request meets this **scope of {xportr}**. If your Pull Request moves beyond this scope, please get in touch with the `{xportr}` team on [slack](https://pharmaverse.slack.com/archives/C030EB2M4GM) or create an issue to discuss.

Please check off each task box as an acknowledgment that you completed the task. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `main` branch until you have checked off each task.

### Changes Description

Resolve issues indicated in #275

### Task List

- [x] The spirit of xportr is met in your Pull Request
- [x] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [x] Summary of changes filled out in the above Changes Description. Can be removed or left blank if changes are minor/self-explanatory.
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/). Use `styler` package and functions to style files accordingly.
- [x] New functions or arguments follow established convention found in the [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers).
- [x] Updated relevant unit tests or have written new unit tests. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Unit-Tests) for conventions used in this package.
- [x] Creation/updated relevant roxygen headers and examples. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers) for conventions used in this package.
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [x] Run `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new/updated functions occur on the "Reference" page.
- [x] Update `NEWS.md` if the changes pertain to a user-facing function (i.e. it has an `@export` tag) or documentation aimed at users (rather than developers)
- [x] The `NEWS.md` entry should go under the `# xportr development version` section. Don't worry about updating the version because it will be auto-updated using the `vbump.yaml` CI.
- [x] Address any updates needed for vignettes and/or templates.
- [x] Link the issue Development Panel so that it closes after successful merging.
- [x] The developer is responsible for fixing merge conflicts not the Reviewer.
- [x] Pat yourself on the back for a job well done! Much love to your accomplishment!
