### PR TITLE
Closes #271 add_hms: add hms to xportr.numeric_types and add details to xpor…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: xportr
 Title: Utilities to Output CDISC SDTM/ADaM XPT Files
-Version: 0.4.1
+Version: 0.4.2
 Authors@R: c(
     person("Eli", "Miller", , "Eli.Miller@AtorusResearch.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-2127-9456")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: xportr
 Title: Utilities to Output CDISC SDTM/ADaM XPT Files
-Version: 0.4.2
+Version: 0.4.1
 Authors@R: c(
     person("Eli", "Miller", , "Eli.Miller@AtorusResearch.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-2127-9456")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# xportr 0.4.2
+# xportr (development version)
 
 * `"hms"` was added to the default value of the `xportr.numeric_types` option.
 This ensures that `{xportr}` works smoothly with variables created by

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# xportr 0.4.2
+
+* `"hms"` was added to the default value of the `xportr.numeric_types` option.
+This ensures that `{xportr}` works smoothly with variables created by
+`admiral::derive_vars_dtm_to_tm()`. (#271)
+
+* More details were added to the messages of `xportr_type()`. (#271)
+
 # xportr 0.4.1
 
 ## New Feature

--- a/R/messages.R
+++ b/R/messages.R
@@ -88,11 +88,39 @@ type_log <- function(meta_ordered, type_mismatch_ind, verbose) {
 
   if (length(type_mismatch_ind) > 0) {
     cli_h2("Variable type mismatches found.")
-    cli_alert_success("{ length(type_mismatch_ind) } variables coerced")
+    cli_alert_success("{ length(type_mismatch_ind) } variable{?s} coerced")
 
+    meta_mismatch <- meta_ordered[type_mismatch_ind, ]
     message <- glue(
       "Variable type(s) in dataframe don't match metadata: ",
-      "{encode_vars(meta_ordered[type_mismatch_ind, 'variable'])}"
+      "{encode_vars(meta_ordered[type_mismatch_ind, 'variable'])}\n",
+      paste0(
+        "- `", meta_mismatch$variable, "` was coerced to ",
+        ifelse(meta_mismatch$type.y == "_character", "<character>", "<numeric>"),
+        ". (type in data: ", meta_mismatch$orig_type_data, ", type in metadata: ",
+        meta_mismatch$orig_type_meta, ")",
+        collapse = "\n"
+      ),
+      paste(
+        "\ni Types in metadata considered as character (xportr.character_metadata_types option):",
+        encode_vals(getOption("xportr.character_metadata_types")),
+        collapse = " "
+      ),
+      paste(
+        "\ni Types in metadata considered as numeric (xportr.numeric_metadata_types option):",
+        encode_vals(getOption("xportr.numeric_metadata_types")),
+        collapse = " "
+      ),
+      paste(
+        "\ni Types in data considered as character (xportr.character_types option):",
+        encode_vals(getOption("xportr.character_types")),
+        collapse = " "
+      ),
+      paste(
+        "\ni Types in data considered as numeric (xportr.numeric_types option):",
+        encode_vals(getOption("xportr.numeric_types")),
+        collapse = " "
+      )
     )
 
     xportr_logger(message, verbose)

--- a/R/options.R
+++ b/R/options.R
@@ -15,42 +15,42 @@
 #' @section Options with `options()`:
 #'
 #' \describe{
-#' \item{xportr.df_domain_name}{defaults to `"dataset"`}:
-#'  The name of the domain "name" column in dataset metadata.
-#' \item{xportr.df_label}{defaults to `"label"`}:
-#'  The column noting the dataset label in dataset metadata.
-#' \item{xportr.domain_name}{defaults to `"dataset"`}:
-#'  The name of the domain "name" column in variable metadata.
-#' \item{xportr.variable_name}{defaults to `"variable"`}:
-#'  The name of the variable "name" in variable metadata.
-#' \item{xportr.type_name}{defaults to `"type"`}:
-#'  The name of the variable type column in variable metadata.
-#' \item{xportr.label}{defaults to `"label"`}:
-#'  The name of the variable label column in variable metadata.
-#' \item{xportr.length}{defaults to `"length"`}:
-#'  The name of the variable length column in variable metadata.
-#' \item{xportr.order_name}{defaults to `"order"`}:
-#'  The name of the variable order column in variable metadata.
-#' \item{xportr.format_name}{defaults to `"format"`}:
-#'  The name of the variable format column in variable metadata.
-#' \item{xportr.format_verbose}{defaults to `"none"`}:
-#'  The default argument for the 'verbose' argument for `xportr_format`.
-#' \item{xportr.label_verbose}{defaults to `"none"`}:
-#'  The default argument for the 'verbose' argument for `xportr_label`.
-#' \item{xportr.length_verbose}{defaults to `"none"`}:
-#'  The default argument for the 'verbose' argument for `xportr_length`.
-#' \item{xportr.type_verbose}{defaults to `"label"`}:
-#'  The default argument for the 'verbose' argument for `xportr_type`.
-#' \item{xportr.character_types}{defaults to `"character"`}:
-#'  The default character vector used to explicitly coerce R classes to character XPT types.
+#' \item{xportr.df_domain_name}{defaults to `"dataset"`\cr
+#'  The name of the domain "name" column in dataset metadata.}
+#' \item{xportr.df_label}{defaults to `"label"`\cr
+#'  The column noting the dataset label in dataset metadata.}
+#' \item{xportr.domain_name}{defaults to `"dataset"`\cr
+#'  The name of the domain "name" column in variable metadata.}
+#' \item{xportr.variable_name}{defaults to `"variable"`\cr
+#'  The name of the variable "name" in variable metadata.}
+#' \item{xportr.type_name}{defaults to `"type"`\cr
+#'  The name of the variable type column in variable metadata.}
+#' \item{xportr.label}{defaults to `"label"`\cr
+#'  The name of the variable label column in variable metadata.}
+#' \item{xportr.length}{defaults to `"length"`\cr
+#'  The name of the variable length column in variable metadata.}
+#' \item{xportr.order_name}{defaults to `"order"`\cr
+#'  The name of the variable order column in variable metadata.}
+#' \item{xportr.format_name}{defaults to `"format"`\cr
+#'  The name of the variable format column in variable metadata.}
+#' \item{xportr.format_verbose}{defaults to `"none"`\cr
+#'  The default argument for the 'verbose' argument for `xportr_format`.}
+#' \item{xportr.label_verbose}{defaults to `"none"`\cr
+#'  The default argument for the 'verbose' argument for `xportr_label`.}
+#' \item{xportr.length_verbose}{defaults to `"none"`\cr
+#'  The default argument for the 'verbose' argument for `xportr_length`.}
+#' \item{xportr.type_verbose}{defaults to `"label"`\cr
+#'  The default argument for the 'verbose' argument for `xportr_type`.}
+#' \item{xportr.character_types}{defaults to `"character"`\cr
+#'  The default character vector used to explicitly coerce R classes to character XPT types.}
 #' \item{xportr.character_metadata_types}{defaults to `c("character", "char", "text", "date", "posixct", "posixt",
 #'                                              "datetime", "time", "partialdate", "partialtime", "partialdatetime",
-#'                                              "incompletedatetime", "durationdatetime", "intervaldatetime")`}:
-#'  The default character vector used to explicitly coerce R classes to character XPT types.
-#' \item{xportr.numeric_metadata_types}{defaults to `c("integer", "numeric", "num", "float")`}:
-#'  The default character vector used to explicitly coerce R classes to numeric XPT types.
-#' \item{xportr.numeric_types}{defaults to `c("integer", "float", "numeric", "posixct", "posixt", "time", "date")`}:
-#'  The default character vector used to explicitly coerce R classes to numeric XPT types.
+#'                                              "incompletedatetime", "durationdatetime", "intervaldatetime")`\cr
+#'  The default character vector used to explicitly coerce R classes to character XPT types.}
+#' \item{xportr.numeric_metadata_types}{defaults to `c("integer", "numeric", "num", "float")`\cr
+#'  The default character vector used to explicitly coerce R classes to numeric XPT types.}
+#' \item{xportr.numeric_types}{defaults to ``r deparse(getOption("xportr.numeric_types"), width.cutoff = 500)``\cr
+#'  The default character vector used to explicitly coerce R classes to numeric XPT types.}
 #' }
 #'
 #' @section Options with `xportr_options()`:

--- a/R/split.R
+++ b/R/split.R
@@ -36,7 +36,7 @@
 #' adlb <- xportr_split(adlb, "LBCAT")
 xportr_split <- function(.df, split_by = NULL) {
   lifecycle::deprecate_warn(
-    when = "0.5.0",
+    when = "0.4.1",
     what = "xportr_split()",
     with = "xportr_write()",
     details = "Please use the argument `max_gb_size` in the

--- a/R/xportr-package.R
+++ b/R/xportr-package.R
@@ -12,82 +12,82 @@
 #' \itemize{
 #'   \item{
 #'   xportr.df_domain_name - The name of the domain "name" column in dataset
-#'   metadata. Default: "dataset"
+#'   metadata. Default: `"dataset"`
 #'   }
 #'   \item {
 #'   xportr.df_label - The column noting the dataset label in dataset metadata.
-#'   Default: "label"
+#'   Default: `"label"`
 #'   }
 #'   \item{
 #'   xportr.domain_name - The name of the domain "name" column in variable
-#'   metadata. Default: "dataset"
+#'   metadata. Default: `"dataset"`
 #'   }
 #'   \item{
 #'   xportr.variable_name - The name of the variable "name" in variable
-#'   metadata. Default: "variable"
+#'   metadata. Default: `"variable"`
 #'   }
 #'   \item{
 #'   xportr.type_name - The name of the variable type column in variable
-#'   metadata. Default: "type"
+#'   metadata. Default: `"type"`
 #'   }
 #'   \item{
 #'   xportr.label - The name of the variable label column in variable metadata.
-#'   Default: "label"
+#'   Default: `"label"`
 #'   }
 #'   \item{
 #'   xportr.length - The name of the variable length column in variable
-#'   metadata. Default: "length"
+#'   metadata. Default: `"length"`
 #'   }
 #'   \item{
 #'   xportr.order_name - The name of the variable order column in variable
-#'   metadata. Default: "order"
+#'   metadata. Default: `"order"`
 #'   }
 #'   \item{
 #'   xportr.format_name - The name of the variable format column in variable
-#'   metadata. Default: "format"
+#'   metadata. Default: `"format"`
 #'   }
 #'   \item{
 #'   xportr.format_verbose - The default argument for the 'verbose' argument for
-#'   `xportr_format`. Default: "none"
+#'   `xportr_format`. Default: `"none"`
 #'   }
 #'   \item{
 #'   xportr.label_verbose - The default argument for the 'verbose' argument for
-#'   `xportr_label`. Default: "none"
+#'   `xportr_label`. Default: `"none"`
 #'   }
 #'   \item{
 #'   xportr.length_verbose - The default argument for the 'verbose' argument for
-#'   `xportr_length`. Default: "none"
+#'   `xportr_length`. Default: `"none"`
 #'   }
 #'   \item{
 #'   xportr.type_verbose - The default argument for the 'verbose' argument for
-#'   `xportr_type`. Default: "none"
+#'   `xportr_type`. Default: `"none"`
 #'   }
 #'   \item{
 #'   xportr.character_types - The default character vector used to explicitly
-#'   coerce R classes to character XPT types. Default:  "character"
+#'   coerce R classes to character XPT types. Default: `"character"`
 #'   }
 #'   \item{
 #'   xportr.character_metadata_types - The default character vector used to explicitly
-#'   coerce R classes to character XPT types. Default: c("character", "char",
+#'   coerce R classes to character XPT types. Default: `c("character", "char",
 #'   "text", "date", "posixct", "posixt", "datetime", "time", "partialdate",
 #'   "partialtime", "partialdatetime", "incompletedatetime", "durationdatetime",
 #'   "intervaldatetime")`
 #'   }
 #'   \item{
 #'   xportr.numeric_metadata_types - The default character vector used to explicitly
-#'   coerce R classes to numeric XPT types. Default: c("integer", "numeric", "num", "float")
+#'   coerce R classes to numeric XPT types. Default: `c("integer", "numeric", "num", "float")`
 #'   }
 #'   \item{
 #'   xportr.numeric_types - The default character vector used to explicitly
-#'   coerce R classes to numeric XPT types. Default: c("integer", "float",
-#'   "numeric", "posixct", "posixt", "time", "date")
+#'   coerce R classes to numeric XPT types. Default:
+#'   ``r deparse(getOption("xportr.numeric_types"), width.cutoff = 500)``
 #'   }
 #' }
 #'
 #' @section Updating Options:
 #' \itemize{
 #'   \item{For a single session, an option can be changed by
-#'   `option(<optionToChange> = <NewValue>)`}
+#'   `options(<optionToChange> = <NewValue>)`.}
 #'   \item{To change an option for a single projects across sessions in that
 #'   projects, place the options update in the `.Rprofile` in that project
 #'   directory.}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -33,7 +33,7 @@ xportr_options_list <- list(
   ),
   xportr.numeric_types = getOption(
     "xportr.numeric_types",
-    c("integer", "float", "numeric", "posixct", "posixt", "time", "date")
+    c("integer", "float", "numeric", "posixct", "posixt", "time", "date", "hms")
   )
 )
 

--- a/man/xportr-package.Rd
+++ b/man/xportr-package.Rd
@@ -18,75 +18,72 @@ customize how \code{xportr} works in your environment.
 \itemize{
 \item{
 xportr.df_domain_name - The name of the domain "name" column in dataset
-metadata. Default: "dataset"
+metadata. Default: \code{"dataset"}
 }
 \item {
 xportr.df_label - The column noting the dataset label in dataset metadata.
-Default: "label"
+Default: \code{"label"}
 }
 \item{
 xportr.domain_name - The name of the domain "name" column in variable
-metadata. Default: "dataset"
+metadata. Default: \code{"dataset"}
 }
 \item{
 xportr.variable_name - The name of the variable "name" in variable
-metadata. Default: "variable"
+metadata. Default: \code{"variable"}
 }
 \item{
 xportr.type_name - The name of the variable type column in variable
-metadata. Default: "type"
+metadata. Default: \code{"type"}
 }
 \item{
 xportr.label - The name of the variable label column in variable metadata.
-Default: "label"
+Default: \code{"label"}
 }
 \item{
 xportr.length - The name of the variable length column in variable
-metadata. Default: "length"
+metadata. Default: \code{"length"}
 }
 \item{
 xportr.order_name - The name of the variable order column in variable
-metadata. Default: "order"
+metadata. Default: \code{"order"}
 }
 \item{
 xportr.format_name - The name of the variable format column in variable
-metadata. Default: "format"
+metadata. Default: \code{"format"}
 }
 \item{
 xportr.format_verbose - The default argument for the 'verbose' argument for
-\code{xportr_format}. Default: "none"
+\code{xportr_format}. Default: \code{"none"}
 }
 \item{
 xportr.label_verbose - The default argument for the 'verbose' argument for
-\code{xportr_label}. Default: "none"
+\code{xportr_label}. Default: \code{"none"}
 }
 \item{
 xportr.length_verbose - The default argument for the 'verbose' argument for
-\code{xportr_length}. Default: "none"
+\code{xportr_length}. Default: \code{"none"}
 }
 \item{
 xportr.type_verbose - The default argument for the 'verbose' argument for
-\code{xportr_type}. Default: "none"
+\code{xportr_type}. Default: \code{"none"}
 }
 \item{
 xportr.character_types - The default character vector used to explicitly
-coerce R classes to character XPT types. Default:  "character"
+coerce R classes to character XPT types. Default: \code{"character"}
 }
 \item{
 xportr.character_metadata_types - The default character vector used to explicitly
-coerce R classes to character XPT types. Default: c("character", "char",
-"text", "date", "posixct", "posixt", "datetime", "time", "partialdate",
-"partialtime", "partialdatetime", "incompletedatetime", "durationdatetime",
-"intervaldatetime")`
+coerce R classes to character XPT types. Default: \code{c("character", "char", "text", "date", "posixct", "posixt", "datetime", "time", "partialdate", "partialtime", "partialdatetime", "incompletedatetime", "durationdatetime", "intervaldatetime")}
 }
 \item{
 xportr.numeric_metadata_types - The default character vector used to explicitly
-coerce R classes to numeric XPT types. Default: c("integer", "numeric", "num", "float")
+coerce R classes to numeric XPT types. Default: \code{c("integer", "numeric", "num", "float")}
 }
 \item{
 xportr.numeric_types - The default character vector used to explicitly
-coerce R classes to numeric XPT types. Default: c("integer", "float",
-"numeric", "posixct", "posixt", "time", "date")
+coerce R classes to numeric XPT types. Default:
+\code{c("integer", "float", "numeric", "posixct", "posixt", "time", "date", "hms")}
 }
 }
 }
@@ -95,7 +92,7 @@ coerce R classes to numeric XPT types. Default: c("integer", "float",
 
 \itemize{
 \item{For a single session, an option can be changed by
-\verb{option(<optionToChange> = <NewValue>)}}
+\verb{options(<optionToChange> = <NewValue>)}.}
 \item{To change an option for a single projects across sessions in that
 projects, place the options update in the \code{.Rprofile} in that project
 directory.}

--- a/man/xportr_options.Rd
+++ b/man/xportr_options.Rd
@@ -23,40 +23,40 @@ xportr related options of this type are prefixed with \code{"xportr."}.
 
 
 \describe{
-\item{xportr.df_domain_name}{defaults to \code{"dataset"}}:
-The name of the domain "name" column in dataset metadata.
-\item{xportr.df_label}{defaults to \code{"label"}}:
-The column noting the dataset label in dataset metadata.
-\item{xportr.domain_name}{defaults to \code{"dataset"}}:
-The name of the domain "name" column in variable metadata.
-\item{xportr.variable_name}{defaults to \code{"variable"}}:
-The name of the variable "name" in variable metadata.
-\item{xportr.type_name}{defaults to \code{"type"}}:
-The name of the variable type column in variable metadata.
-\item{xportr.label}{defaults to \code{"label"}}:
-The name of the variable label column in variable metadata.
-\item{xportr.length}{defaults to \code{"length"}}:
-The name of the variable length column in variable metadata.
-\item{xportr.order_name}{defaults to \code{"order"}}:
-The name of the variable order column in variable metadata.
-\item{xportr.format_name}{defaults to \code{"format"}}:
-The name of the variable format column in variable metadata.
-\item{xportr.format_verbose}{defaults to \code{"none"}}:
-The default argument for the 'verbose' argument for \code{xportr_format}.
-\item{xportr.label_verbose}{defaults to \code{"none"}}:
-The default argument for the 'verbose' argument for \code{xportr_label}.
-\item{xportr.length_verbose}{defaults to \code{"none"}}:
-The default argument for the 'verbose' argument for \code{xportr_length}.
-\item{xportr.type_verbose}{defaults to \code{"label"}}:
-The default argument for the 'verbose' argument for \code{xportr_type}.
-\item{xportr.character_types}{defaults to \code{"character"}}:
-The default character vector used to explicitly coerce R classes to character XPT types.
-\item{xportr.character_metadata_types}{defaults to \code{c("character", "char", "text", "date", "posixct", "posixt", "datetime", "time", "partialdate", "partialtime", "partialdatetime", "incompletedatetime", "durationdatetime", "intervaldatetime")}}:
-The default character vector used to explicitly coerce R classes to character XPT types.
-\item{xportr.numeric_metadata_types}{defaults to \code{c("integer", "numeric", "num", "float")}}:
-The default character vector used to explicitly coerce R classes to numeric XPT types.
-\item{xportr.numeric_types}{defaults to \code{c("integer", "float", "numeric", "posixct", "posixt", "time", "date")}}:
-The default character vector used to explicitly coerce R classes to numeric XPT types.
+\item{xportr.df_domain_name}{defaults to \code{"dataset"}\cr
+The name of the domain "name" column in dataset metadata.}
+\item{xportr.df_label}{defaults to \code{"label"}\cr
+The column noting the dataset label in dataset metadata.}
+\item{xportr.domain_name}{defaults to \code{"dataset"}\cr
+The name of the domain "name" column in variable metadata.}
+\item{xportr.variable_name}{defaults to \code{"variable"}\cr
+The name of the variable "name" in variable metadata.}
+\item{xportr.type_name}{defaults to \code{"type"}\cr
+The name of the variable type column in variable metadata.}
+\item{xportr.label}{defaults to \code{"label"}\cr
+The name of the variable label column in variable metadata.}
+\item{xportr.length}{defaults to \code{"length"}\cr
+The name of the variable length column in variable metadata.}
+\item{xportr.order_name}{defaults to \code{"order"}\cr
+The name of the variable order column in variable metadata.}
+\item{xportr.format_name}{defaults to \code{"format"}\cr
+The name of the variable format column in variable metadata.}
+\item{xportr.format_verbose}{defaults to \code{"none"}\cr
+The default argument for the 'verbose' argument for \code{xportr_format}.}
+\item{xportr.label_verbose}{defaults to \code{"none"}\cr
+The default argument for the 'verbose' argument for \code{xportr_label}.}
+\item{xportr.length_verbose}{defaults to \code{"none"}\cr
+The default argument for the 'verbose' argument for \code{xportr_length}.}
+\item{xportr.type_verbose}{defaults to \code{"label"}\cr
+The default argument for the 'verbose' argument for \code{xportr_type}.}
+\item{xportr.character_types}{defaults to \code{"character"}\cr
+The default character vector used to explicitly coerce R classes to character XPT types.}
+\item{xportr.character_metadata_types}{defaults to \code{c("character", "char", "text", "date", "posixct", "posixt", "datetime", "time", "partialdate", "partialtime", "partialdatetime", "incompletedatetime", "durationdatetime", "intervaldatetime")}\cr
+The default character vector used to explicitly coerce R classes to character XPT types.}
+\item{xportr.numeric_metadata_types}{defaults to \code{c("integer", "numeric", "num", "float")}\cr
+The default character vector used to explicitly coerce R classes to numeric XPT types.}
+\item{xportr.numeric_types}{defaults to \code{c("integer", "float", "numeric", "posixct", "posixt", "time", "date", "hms")}\cr
+The default character vector used to explicitly coerce R classes to numeric XPT types.}
 }
 }
 

--- a/man/xportr_type.Rd
+++ b/man/xportr_type.Rd
@@ -32,12 +32,13 @@ metadata now renamed with \code{metadata}}
 Returns the modified table.
 }
 \description{
-XPT v5 datasets only have data types of character and numeric. \code{xportr_type}
+XPT v5 datasets only have data types of character and numeric. \code{xportr_type()}
 attempts to collapse R classes to those two XPT types. The
 'xportr.character_types' option is used to explicitly collapse the class of a
-column to character using \code{as.character}. Similarly, 'xportr.numeric_types'
-will collapse a column to a numeric type. If no type is passed for a
-variable, it is assumed to be numeric and coerced with \code{as.numeric()}.
+column to character using \code{as.character()}. Similarly, 'xportr.numeric_types'
+will collapse a column to a numeric type. (See \code{xportr_options()} for default
+values of these options.) If no type is passed for a variable, it is assumed
+to be numeric and coerced with \code{as.numeric()}.
 }
 \details{
 Certain care should be taken when using timing variables. R serializes dates
@@ -49,7 +50,7 @@ should happen with variables that appear to be used to denote time.
 \section{Messaging}{
  \code{type_log()} is the primary messaging tool for
 \code{xportr_type()}. The number of column types that mismatch the reported type
-in the metadata, if any, is reported by by \code{xportr_type()}. If there are any
+in the metadata, if any, is reported by \code{xportr_type()}. If there are any
 type mismatches, and the 'verbose' argument is 'stop', 'warn', or
 'message', each mismatch will be detailed with the actual type in the data
 and the type noted in the metadata.

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -300,7 +300,7 @@ test_that("type Test 10: Var date types (--DTC) coerced as expected and raise me
       xportr_type()
   ) %>%
     expect_message("Variable type mismatches found.") %>%
-    expect_message("[0-9+] variables coerced")
+    expect_message("[0-9+] variables? coerced")
 
   expect_equal(purrr::map_chr(df2, class), c(
     STUDYID = "character", USUBJID = "character",

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -310,9 +310,12 @@ test_that("xportr_write Test 17: `split_by` attribute is used to split the data"
   on.exit(unlink(tmpdir))
 
   dts <- data_to_save()
+  expect_warning(
   dts %>%
     xportr_split(split_by = "X") %>%
-    xportr_write(path = tmp)
+    xportr_write(path = tmp),
+  class = "lifecycle_warning_deprecated"
+  )
 
   expect_true(
     file.exists(file.path(tmpdir, "xyz1.xpt"))

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -311,10 +311,10 @@ test_that("xportr_write Test 17: `split_by` attribute is used to split the data"
 
   dts <- data_to_save()
   expect_warning(
-  dts %>%
-    xportr_split(split_by = "X") %>%
-    xportr_write(path = tmp),
-  class = "lifecycle_warning_deprecated"
+    dts %>%
+      xportr_split(split_by = "X") %>%
+      xportr_write(path = tmp),
+    class = "lifecycle_warning_deprecated"
   )
 
   expect_true(


### PR DESCRIPTION
…tr_type() messages

### Thank you for your Pull Request!

We have developed a Pull Request template to aid you and our reviewers. Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the xportr codebase remains robust and consistent.

### The scope of `{xportr}`

`{xportr}`'s scope is to enable R users to write out submission compliant `xpt` files that can be delivered to a Health Authority or to downstream validation software programs. We see labels, lengths, types, ordering and formats from a dataset specification object (SDTM and ADaM) as being our primary focus. We also see messaging and warnings to users around applying information from the specification file as a primary focus. Please make sure your Pull Request meets this **scope of {xportr}**. If your Pull Request moves beyond this scope, please get in touch with the `{xportr}` team on [slack](https://pharmaverse.slack.com/archives/C030EB2M4GM) or create an issue to discuss.

Please check off each task box as an acknowledgment that you completed the task. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `main` branch until you have checked off each task.

### Changes Description

- `"hms"` added to `xportr.numeric_types` option
- More details added to messages of `xportr_type()`

### Task List

- [x] The spirit of xportr is met in your Pull Request
- [x] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [x] Summary of changes filled out in the above Changes Description. Can be removed or left blank if changes are minor/self-explanatory.
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/). Use `styler` package and functions to style files accordingly.
- [x] New functions or arguments follow established convention found in the [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers).
- [x] Updated relevant unit tests or have written new unit tests. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Unit-Tests) for conventions used in this package.
- [x] Creation/updated relevant roxygen headers and examples. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers) for conventions used in this package.
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [x] Run `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new/updated functions occur on the "Reference" page.
- [x] Update `NEWS.md` if the changes pertain to a user-facing function (i.e. it has an `@export` tag) or documentation aimed at users (rather than developers)
- [x] The `NEWS.md` entry should go under the `# xportr development version` section. Don't worry about updating the version because it will be auto-updated using the `vbump.yaml` CI.
- [x] Address any updates needed for vignettes and/or templates.
- [x] Link the issue Development Panel so that it closes after successful merging.
- [x] The developer is responsible for fixing merge conflicts not the Reviewer.
- [x] Pat yourself on the back for a job well done! Much love to your accomplishment!
