### PR TITLE
Per #269, updated the messaging in 'xportr_order()` to fix a mistatem…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # xportr (development version)
 
+* Updated order messaging to clarify some messaging when all data in dataset is
+found in the specification. (#269)
+
 * `"hms"` was added to the default value of the `xportr.numeric_types` option.
 This ensures that `{xportr}` works smoothly with variables created by
 `admiral::derive_vars_dtm_to_tm()`. (#271)

--- a/R/messages.R
+++ b/R/messages.R
@@ -198,7 +198,7 @@ var_ord_msg <- function(reordered_vars, moved_vars, verbose) {
     )
     xportr_logger(message, verbose)
   } else {
-    cli_h2("All variables in specification file are in dataset")
+    cli_h2("All variables in dataset are found in `metadata`")
   }
 
   if (length(reordered_vars) > 0) {

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -624,7 +624,7 @@ test_that("metadata Test 29: Variable ordering messaging is correct", {
   # Metadata versions
   xportr_metadata(df, df_meta, domain = "df", verbose = "message") %>%
     xportr_order() %>%
-    expect_message("All variables in specification file are in dataset") %>%
+    expect_message("All variables in dataset are found in `metadata`") %>%
     expect_condition("4 reordered in dataset") %>%
     expect_message("Variable reordered in `.df`: `a`, `b`, `c`, and `d`")
 

--- a/tests/testthat/test-order.R
+++ b/tests/testthat/test-order.R
@@ -137,7 +137,7 @@ test_that("order Test 8: Variable ordering messaging is correct", {
   local_cli_theme()
   suppressMessages(
     xportr_order(df, df_meta, verbose = "message", domain = "df") %>%
-      expect_message("All variables in specification file are in dataset") %>%
+      expect_message("All variables in dataset are found in `metadata`") %>%
       expect_condition("4 reordered in dataset") %>%
       expect_message("Variable reordered in `.df`: `a`, `b`, `c`, and `d`")
   )
@@ -172,13 +172,13 @@ test_that("order Test 10: Gets warning when metadata has multiple rows with same
   # Checks that message appears when xportr.domain_name is invalid
   suppressMessages(multiple_vars_in_spec_helper(xportr_order) %>%
     # expect_message() are being caught to provide clean test without output      #nolint
-    expect_message("All variables in specification file are in dataset") %>%
+    expect_message("All variables in dataset are found in `metadata`") %>%
     expect_message("All variables in dataset are ordered"))
 
   # Checks that message doesn't appear when xportr.domain_name is valid
   suppressMessages(multiple_vars_in_spec_helper2(xportr_order) %>%
     # expect_message() are being caught to provide clean test without output     #nolint
-    expect_message("All variables in specification file are in dataset") %>%
+    expect_message("All variables in dataset are found in `metadata`") %>%
     expect_message("All variables in dataset are ordered"))
 })
 


### PR DESCRIPTION
Per #269, updated the messaging in 'xportr_order()` to fix a misstatement.

The function is concerned about if variables in the dataset aren't in the specification file, not the other way around. other way around.

Closes #269 

### Thank you for your Pull Request!

We have developed a Pull Request template to aid you and our reviewers. Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the xportr codebase remains robust and consistent.

### The scope of `{xportr}`

`{xportr}`'s scope is to enable R users to write out submission compliant `xpt` files that can be delivered to a Health Authority or to downstream validation software programs. We see labels, lengths, types, ordering and formats from a dataset specification object (SDTM and ADaM) as being our primary focus. We also see messaging and warnings to users around applying information from the specification file as a primary focus. Please make sure your Pull Request meets this **scope of {xportr}**. If your Pull Request moves beyond this scope, please get in touch with the `{xportr}` team on [slack](https://pharmaverse.slack.com/archives/C030EB2M4GM) or create an issue to discuss.

Please check off each task box as an acknowledgment that you completed the task. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `main` branch until you have checked off each task.

### Changes Description

_(descriptions of changes)_

### Task List

- [x] The spirit of xportr is met in your Pull Request
- [x] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [x] Summary of changes filled out in the above Changes Description. Can be removed or left blank if changes are minor/self-explanatory.
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/). Use `styler` package and functions to style files accordingly.
- [x] New functions or arguments follow established convention found in the [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers).
- [x] Updated relevant unit tests or have written new unit tests. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Unit-Tests) for conventions used in this package.
- [x] Creation/updated relevant roxygen headers and examples. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers) for conventions used in this package.
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [x] Run `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new/updated functions occur on the "Reference" page.
- [x] Update `NEWS.md` if the changes pertain to a user-facing function (i.e. it has an `@export` tag) or documentation aimed at users (rather than developers)
- [x] The `NEWS.md` entry should go under the `# xportr development version` section. Don't worry about updating the version because it will be auto-updated using the `vbump.yaml` CI.
- [x] Address any updates needed for vignettes and/or templates.
- [x] Link the issue Development Panel so that it closes after successful merging.
- [x] The developer is responsible for fixing merge conflicts not the Reviewer.
- [x] Pat yourself on the back for a job well done! Much love to your accomplishment!
