### PR TITLE
Add missing domain logging

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # xportr (development version)
 
+* Added logging to the `domain` argument in `xportr` functions to notify user if
+the domain passed doesn't exist in the metadata. (#260)
+
 * `"hms"` was added to the default value of the `xportr.numeric_types` option.
 This ensures that `{xportr}` works smoothly with variables created by
 `admiral::derive_vars_dtm_to_tm()`. (#271)

--- a/R/format.R
+++ b/R/format.R
@@ -139,6 +139,9 @@ xportr_format <- function(.df,
   if (inherits(metadata, "Metacore")) metadata <- metadata$var_spec
 
   if (domain_name %in% names(metadata) && !is.null(domain)) {
+    # If 'domain' passed by user isn't found in metadata, return error
+    if (!domain %in% metadata[[domain_name]]) log_no_domain(domain, domain_name, verbose)
+
     metadata <- metadata %>%
       filter(!!sym(domain_name) == .env$domain & !is.na(!!sym(format_name)))
   } else {

--- a/R/label.R
+++ b/R/label.R
@@ -96,6 +96,9 @@ xportr_label <- function(.df,
   if (inherits(metadata, "Metacore")) metadata <- metadata$var_spec
 
   if (domain_name %in% names(metadata) && !is.null(domain)) {
+    # If 'domain' passed by user isn't found in metadata, return error
+    if (!domain %in% metadata[[domain_name]]) log_no_domain(domain, domain_name, verbose)
+
     metadata <- metadata %>%
       dplyr::filter(!!sym(domain_name) == .env$domain)
   } else {

--- a/R/length.R
+++ b/R/length.R
@@ -105,6 +105,9 @@ xportr_length <- function(.df,
   if (inherits(metadata, "Metacore")) metadata <- metadata$var_spec
 
   if (domain_name %in% names(metadata) && !is.null(domain)) {
+    # If 'domain' passed by user isn't found in metadata, return error
+    if (!domain %in% metadata[[domain_name]]) log_no_domain(domain, domain_name, verbose)
+
     metadata <- metadata %>%
       filter(!!sym(domain_name) == .env$domain)
   } else {

--- a/R/messages.R
+++ b/R/messages.R
@@ -242,3 +242,21 @@ max_length_msg <- function(max_length, verbose) {
     )
   }
 }
+
+#' Utility for Missing Domain
+#'
+#' @param domain Domain passed by user
+#' @param domain_name Name of the domain column in metadata
+#' @param verbose Provides additional messaging for user
+#'
+#' @return Output to Console
+#' @noRd
+log_no_domain <- function(domain, domain_name, verbose) {
+  cli_h2("Domain not found in metadata.")
+  xportr_logger(
+    glue(
+      "Domain '{domain}' not found in metadata '{domain_name}' column."
+    ),
+    type = verbose
+  )
+}

--- a/R/order.R
+++ b/R/order.R
@@ -99,6 +99,9 @@ xportr_order <- function(.df,
   if (inherits(metadata, "Metacore")) metadata <- metadata$ds_vars
 
   if (domain_name %in% names(metadata) && !is.null(domain)) {
+    # If 'domain' passed by user isn't found in metadata, return error
+    if (!domain %in% metadata[[domain_name]]) log_no_domain(domain, domain_name, verbose)
+
     metadata <- metadata %>%
       dplyr::filter(!!sym(domain_name) == .env$domain & !is.na(!!sym(order_name)))
   } else {

--- a/R/type.R
+++ b/R/type.R
@@ -113,6 +113,9 @@ xportr_type <- function(.df,
   if (inherits(metadata, "Metacore")) metadata <- metadata$var_spec
 
   if (domain_name %in% names(metadata) && !is.null(domain)) {
+    # If 'domain' passed by user isn't found in metadata, return error
+    if (!domain %in% metadata[[domain_name]]) log_no_domain(domain, domain_name, verbose)
+
     metadata <- metadata %>%
       filter(!!sym(domain_name) == .env$domain)
   }

--- a/tests/testthat/test-messages.R
+++ b/tests/testthat/test-messages.R
@@ -76,3 +76,14 @@ test_that("messages Test 4: Renamed variables messages are shown", {
     expect_message("Var . : '.*' was renamed to '.*'") %>%
     expect_message("Duplicate renamed term\\(s\\) were created")
 })
+
+# no_domain_log ----
+## Test 5: no_domain_log: No domain messages are shown ----
+test_that("messages Test 5: No domain messages are shown", {
+  # Remove empty lines in cli theme
+  local_cli_theme()
+
+  log_no_domain("adsl", "domains", "message") %>%
+    expect_message("Domain not found in metadata.") %>%
+    expect_message("Domain 'adsl' not found in metadata 'domains' column.")
+})

--- a/tests/testthat/test-messages.R
+++ b/tests/testthat/test-messages.R
@@ -86,4 +86,22 @@ test_that("messages Test 5: No domain messages are shown", {
   log_no_domain("adsl", "domains", "message") %>%
     expect_message("Domain not found in metadata.") %>%
     expect_message("Domain 'adsl' not found in metadata 'domains' column.")
+
+  adsl <- data.frame(
+    USUBJID = c(1001, 1002, 1003),
+    BRTHDT = c(1, 1, 2)
+  )
+
+  metadata <- data.frame(
+    dataset = c("adsl", "adsl"),
+    variable = c("USUBJID", "BRTHDT"),
+    order = c(1, 2)
+  )
+
+  xportr_order(adsl, metadata, "wrong_adsl", verbose = "message") %>%
+    expect_message("Domain not found in metadata.") %>%
+    expect_message("Domain 'wrong_adsl' not found in metadata 'dataset' column.") %>%
+    expect_message("2 variables not in spec and moved to end") %>%
+    expect_message("Variable moved to end in `.df`: `USUBJID` and `BRTHDT`") %>%
+    expect_message("All variables in dataset are ordered")
 })

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -231,11 +231,11 @@ test_that("type Test 7: xportr_type: date variables are not converted to numeric
   adsl_original$RFICDTM <- as.POSIXct(adsl_original$RFICDTM)
 
   expect_message(
-    adsl_xpt2 <- adsl_original %>% xportr_type(metadata, domain = "adsl_original"),
+    adsl_xpt2 <- adsl_original %>% xportr_type(metadata, domain = "adsl"),
     NA
   )
 
-  attr(adsl_original, "_xportr.df_arg_") <- "adsl_original"
+  attr(adsl_original, "_xportr.df_arg_") <- "adsl"
 
   expect_equal(adsl_original, adsl_xpt2)
 })


### PR DESCRIPTION
Per #260, add logging when a domain is passed that isn't found in the metadata

### Thank you for your Pull Request!

We have developed a Pull Request template to aid you and our reviewers. Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the xportr codebase remains robust and consistent.

Closes #260 

### The scope of `{xportr}`

`{xportr}`'s scope is to enable R users to write out submission compliant `xpt` files that can be delivered to a Health Authority or to downstream validation software programs. We see labels, lengths, types, ordering and formats from a dataset specification object (SDTM and ADaM) as being our primary focus. We also see messaging and warnings to users around applying information from the specification file as a primary focus. Please make sure your Pull Request meets this **scope of {xportr}**. If your Pull Request moves beyond this scope, please get in touch with the `{xportr}` team on [slack](https://pharmaverse.slack.com/archives/C030EB2M4GM) or create an issue to discuss.

Please check off each task box as an acknowledgment that you completed the task. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `main` branch until you have checked off each task.

### Changes Description

_(descriptions of changes)_

### Task List

- [x] The spirit of xportr is met in your Pull Request
- [x] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [x] Summary of changes filled out in the above Changes Description. Can be removed or left blank if changes are minor/self-explanatory.
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/). Use `styler` package and functions to style files accordingly.
- [x] New functions or arguments follow established convention found in the [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers).
- [x] Updated relevant unit tests or have written new unit tests. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Unit-Tests) for conventions used in this package.
- [x] Creation/updated relevant roxygen headers and examples. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers) for conventions used in this package.
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [x] Run `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new/updated functions occur on the "Reference" page.
- [x] Update `NEWS.md` if the changes pertain to a user-facing function (i.e. it has an `@export` tag) or documentation aimed at users (rather than developers)
- [x] The `NEWS.md` entry should go under the `# xportr development version` section. Don't worry about updating the version because it will be auto-updated using the `vbump.yaml` CI.
- [x] Address any updates needed for vignettes and/or templates.
- [x] Link the issue Development Panel so that it closes after successful merging.
- [x] The developer is responsible for fixing merge conflicts not the Reviewer.
- [x] Pat yourself on the back for a job well done! Much love to your accomplishment!
