### PR TITLE
Update docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,4 +52,4 @@ VignetteBuilder:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/R/df_label.R
+++ b/R/df_label.R
@@ -3,8 +3,8 @@
 #' Assigns dataset label from a dataset level metadata to a given data frame.
 #' This is stored in the 'label' attribute of the dataframe.
 #'
-#' @param metadata A data frame containing dataset. See 'Metadata' section for
-#'   details.
+#' @param metadata A data frame containing dataset level metadata. See 'Metadata'
+#'   section for details.
 #' @inheritParams xportr_length
 #'
 #' @return Data frame with label attributes.

--- a/R/utils-xportr.R
+++ b/R/utils-xportr.R
@@ -407,9 +407,9 @@ variable_max_length <- function(.df) {
 #'
 #' Improvement on the message clarity over the default assert(...) messages.
 #' @noRd
-#' @param metadata A data frame or `Metacore` object containing variable level
+#' @param metadata A data frame or `Metacore` object containing dataset or variable
+#'   level metadata.
 #' @inheritParams checkmate::check_logical
-#' metadata.
 check_metadata <- function(metadata, include_fun_message, null.ok = FALSE) { # nolint: object_name.
   if (is.null(metadata) && null.ok) {
     return(TRUE)
@@ -433,9 +433,9 @@ check_metadata <- function(metadata, include_fun_message, null.ok = FALSE) { # n
 
 #' Custom assertion for metadata object
 #' @noRd
-#' @param metadata A data frame or `Metacore` object containing variable level
+#' @param metadata A data frame or `Metacore` object containing dataset or variable
+#'   level metadata.
 #' @inheritParams checkmate::check_logical
-#' metadata.
 assert_metadata <- function(metadata,
                             include_fun_message = TRUE,
                             null.ok = FALSE, # nolint: object_name.

--- a/R/write.R
+++ b/R/write.R
@@ -9,6 +9,9 @@
 #'   used as `xpt` name.
 #' @param max_size_gb Maximum size in GB of the exported file(s). If size of xpt file exceeds the specified maximum,
 #' it will split the data frame into multiple exported chunk(s).
+#' @param metadata A data frame containing dataset level metadata. See 'Metadata'
+#'   section for details. If provided, `xportr_df_label()` will be called to set
+#'   the dataset label before writing the XPT file.
 #' @param label `r lifecycle::badge("deprecated")` Previously used to to set the Dataset label.
 #' Use the `metadata` argument to set the dataset label.
 #' @param strict_checks If TRUE, xpt validation will report errors and not write

--- a/man/xportr.Rd
+++ b/man/xportr.Rd
@@ -42,7 +42,7 @@ Returns the input dataframe invisibly
 Wrapper to apply all core xportr functions and write xpt
 }
 \examples{
-\dontshow{if (requireNamespace("magrittr")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("magrittr")) withAutoprint(\{ # examplesIf}
 data("adsl_xportr", "dataset_spec", "var_spec")
 adsl <- adsl_xportr
 

--- a/man/xportr_df_label.Rd
+++ b/man/xportr_df_label.Rd
@@ -9,8 +9,8 @@ xportr_df_label(.df, metadata = NULL, domain = NULL, metacore = deprecated())
 \arguments{
 \item{.df}{A data frame of CDISC standard.}
 
-\item{metadata}{A data frame containing dataset. See 'Metadata' section for
-details.}
+\item{metadata}{A data frame containing dataset level metadata. See 'Metadata'
+section for details.}
 
 \item{domain}{Appropriate CDISC dataset name, e.g. ADAE, DM. Used to subset
 the metadata object.}

--- a/man/xportr_write.Rd
+++ b/man/xportr_write.Rd
@@ -23,8 +23,9 @@ used as \code{xpt} name.}
 \item{max_size_gb}{Maximum size in GB of the exported file(s). If size of xpt file exceeds the specified maximum,
 it will split the data frame into multiple exported chunk(s).}
 
-\item{metadata}{A data frame containing dataset. See 'Metadata' section for
-details.}
+\item{metadata}{A data frame containing dataset level metadata. See 'Metadata'
+section for details. If provided, \code{xportr_df_label()} will be called to set
+the dataset label before writing the XPT file.}
 
 \item{domain}{Appropriate CDISC dataset name, e.g. ADAE, DM. Used to subset
 the metadata object.}


### PR DESCRIPTION
Closes #301

### The scope of `{xportr}`

`{xportr}`'s scope is to enable R users to write out submission compliant `xpt` files that can be delivered to a Health Authority or to downstream validation software programs. We see labels, lengths, types, ordering and formats from a dataset specification object (SDTM and ADaM) as being our primary focus. We also see messaging and warnings to users around applying information from the specification file as a primary focus. Please make sure your Pull Request meets this **scope of {xportr}**. If your Pull Request moves beyond this scope, please get in touch with the `{xportr}` team on [slack](https://pharmaverse.slack.com/archives/C030EB2M4GM) or create an issue to discuss.

Please check off each task box as an acknowledgment that you completed the task. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `main` branch until you have checked off each task.

### Changes Description

_(descriptions of changes)_

### Task List

- [x] The spirit of xportr is met in your Pull Request
- [x] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [x] Summary of changes filled out in the above Changes Description. Can be removed or left blank if changes are minor/self-explanatory.
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/). Use `styler` package and functions to style files accordingly.
- [x] New functions or arguments follow established convention found in the [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers).
- [x] Updated relevant unit tests or have written new unit tests. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Unit-Tests) for conventions used in this package.
- [x] Creation/updated relevant roxygen headers and examples. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers) for conventions used in this package.
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [x] Run `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new/updated functions occur on the "Reference" page.
- [x] Update `NEWS.md` if the changes pertain to a user-facing function (i.e. it has an `@export` tag) or documentation aimed at users (rather than developers)
- [x] The `NEWS.md` entry should go under the `# xportr development version` section. Don't worry about updating the version because it will be auto-updated using the `vbump.yaml` CI.
- [x] Address any updates needed for vignettes and/or templates.
- [x] Link the issue Development Panel so that it closes after successful merging.
- [x] The developer is responsible for fixing merge conflicts not the Reviewer.
- [x] Pat yourself on the back for a job well done! Much love to your accomplishment!
