### PR TITLE
Closes #328 Configure Test 15 in `test-write.R` to run on CI, and not on CRAN

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -41,6 +41,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      XPORTR_TEST_LARGE_FILES: "true"
     if: >
       !contains(github.event.commits[0].message, '[skip checks]')
     steps:

--- a/tests/testthat/_snaps/write.md
+++ b/tests/testthat/_snaps/write.md
@@ -4,6 +4,6 @@
       xportr_write(large_df, path = tmp)
     Condition
       Warning:
-      i xpt file size is: 8.01GB.
+      i xpt file size is: 5.12GB.
       x XPT file sizes should not exceed 5GB. It is recommended you call `xportr_write` with `max_size_gb` set to 5 or less to split the file into smaller files.
 

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -4,9 +4,6 @@ data_to_save <- function() {
     as_tibble()
 }
 
-# Skip large file tests unless explicitly requested
-test_large_files <- Sys.getenv("XPORTR.TEST_LARGE_FILES", FALSE)
-
 # xportr_write ----
 ## Test 1: exported data can be saved to a file ----
 test_that("xportr_write Test 1: exported data can be saved to a file", {
@@ -269,7 +266,11 @@ test_that("xportr_write Test 14: `max_size_gb` is used to split data frame into 
 
 ## Test 15: Large file sizes are reported and warned ----
 test_that("xportr_write Test 15: Large file sizes are reported and warned", {
+  # Skip large file tests unless explicitly requested
+  test_large_files <- Sys.getenv("XPORTR_TEST_LARGE_FILES") == "true"
   skip_if_not(test_large_files)
+  skip_on_cran()
+
   tmpdir <- tempdir()
   tmp <- file.path(tmpdir, "xyz.xpt")
 

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -277,9 +277,9 @@ test_that("xportr_write Test 15: Large file sizes are reported and warned", {
   on.exit(unlink(tmpdir))
 
   # Large_df should be at least 5GB
-  valid_names <- sprintf("VAR%05d", seq_len(40000))
+  valid_names <- sprintf("VAR%05d", seq_len(32000))
   large_df <- do.call(
-    data.frame, replicate(40000, rep("large", 40000), simplify = FALSE)
+    data.frame, replicate(32000, rep("large", 32000), simplify = FALSE)
   )
   names(large_df) <- valid_names
 


### PR DESCRIPTION
### Thank you for your Pull Request!

We have developed a Pull Request template to aid you and our reviewers. Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the xportr codebase remains robust and consistent.

### The scope of `{xportr}`

`{xportr}`'s scope is to enable R users to write out submission compliant `xpt` files that can be delivered to a Health Authority or to downstream validation software programs. We see labels, lengths, types, ordering and formats from a dataset specification object (SDTM and ADaM) as being our primary focus. We also see messaging and warnings to users around applying information from the specification file as a primary focus. Please make sure your Pull Request meets this **scope of {xportr}**. If your Pull Request moves beyond this scope, please get in touch with the `{xportr}` team on [slack](https://pharmaverse.slack.com/archives/C030EB2M4GM) or create an issue to discuss.

Please check off each task box as an acknowledgment that you completed the task. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `main` branch until you have checked off each task.

### Changes Description

This PR configures Test 15 ("Large file sizes are reported and warned") to behave differently across environments:

* Local Environment: The test is basically skipped by `test-write.R:270-271`. However, users can run it by setting

```r
Sys.setenv("XPORTR_TEST_LARGE_FILES" = "true")
```

* CI Environment: The test will run automatically in GitHub Actions because GHA refers to `XPORTR_TEST_LARGE_FILES: "true"`, which was added in this PR to `.github/workflows/check-standard.yaml` 

* CRAN Environment: CRAN doesn't use GitHub Actions, so the environment variable remains unset(i.e. defaults to an empty string). Therefore, the test will not run on CRAN. There is also the function call `skip_on_cran()` at `test-write.R:272`, added as an additional safety measure.

### Task List

- [x] The spirit of xportr is met in your Pull Request
- [x] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [x] Summary of changes filled out in the above Changes Description. Can be removed or left blank if changes are minor/self-explanatory.
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/). Use `styler` package and functions to style files accordingly.
- [x] New functions or arguments follow established convention found in the [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers).
- [x] Updated relevant unit tests or have written new unit tests. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Unit-Tests) for conventions used in this package.
- [x] Creation/updated relevant roxygen headers and examples. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers) for conventions used in this package.
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [x] Run `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new/updated functions occur on the "Reference" page.
- [x] Update `NEWS.md` if the changes pertain to a user-facing function (i.e. it has an `@export` tag) or documentation aimed at users (rather than developers)
- [x] The `NEWS.md` entry should go under the `# xportr development version` section. Don't worry about updating the version because it will be auto-updated using the `vbump.yaml` CI.
- [x] Address any updates needed for vignettes and/or templates.
- [x] Link the issue Development Panel so that it closes after successful merging.
- [x] The developer is responsible for fixing merge conflicts not the Reviewer.
- [x] Pat yourself on the back for a job well done! Much love to your accomplishment!
