### PR TITLE
Closes #353 Add 'You got options' vignette

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@ time variables. (#298)
 
 ## Documentation
 
+* Added new vignette "You got options" covering `options()` and `xportr_options()` for column name mapping, verbose messaging, and type coercion settings. The corresponding content has been removed from the "Deep Dive" vignette, which now links to the new one. (#353)
+
 ## Miscellaneous
 
 * Standardized function calls by centralizing imports in R/xportr-package.R, replacing inconsistent use of package::function() syntax.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -52,4 +52,5 @@ articles:
     navbar: ~
     contents:
       - deepdive
+      - options
       - agency_standards

--- a/vignettes/deepdive.Rmd
+++ b/vignettes/deepdive.Rmd
@@ -54,7 +54,8 @@ We will also explore the following:
 * What goes in a Submission to a Health Authority, and what role does `{xportr}` play in that Submission?
 * What is `{xportr}` validating behind the scenes?
 * Breakdown of `{xportr}` and a ADaM dataset specification file.
-* Using `options()` and `xportr_metadata()` to enhance your `{xportr}` experience.
+* Using `xportr_metadata()` to reduce repetitive metadata arguments across function calls.
+* Setting `{xportr}` options — see the companion vignette [You got options](options.html) for a full walkthrough.
 * Understanding the warning and error messages for each `{xportr}` function.
 * A brief discussion on future work.
 
@@ -101,23 +102,11 @@ We will focus on warning and error messaging with contrived examples from these 
 **NOTE:** We have made the ADSL and Spec available in this package. Users can find additional datasets and specification files on our [repo](https://github.com/atorus-research/xportr) in the `example_data_specs` folder. This is to keep the package to a minimum size.  
 
 
-## Using `options()` and `xportr_metadata()` to enhance your experience.
+## Using `xportr_metadata()` to reduce repetition
 
-Before we dive into the functions, we want to point out some quality of life utilities to make your `xpt` generation life a little bit easier.
-
-* `options()`
-* `xportr_options()`
-* `xportr_metadata()` 
+`{xportr}` also supports options for controlling column name mapping and messaging verbosity. Rather than covering those here, see the dedicated vignette: [You got options](options.html).
 
 **NOTE:** As long as you have a well-defined _metadata object_ you do NOT need to use `options()` or `xportr_metadata()`, but we find these handy to use and think they deserve a quick mention!
-
-## You've got `options()` or `xportr_options()`
-
-`{xportr}` is built with certain assumptions around specification column names and information in those columns. We have found that each company specification file can differ slightly from our assumptions. For example, one company might call a column `Variables`, another `Variable` and another `variables`.  Rather than trying to regex ourselves out of this situation, we have introduced `options()`.  `options()` allows users to control those assumptions inside `{xportr}` functions based on their needs.
-
-Additionally, we have a helper function `xportr_options()` which works just like the `options()` but, it can also be used to get the current state of the xportr options.
-
-Let's take a look at our example specification file names available in this package. We can see that all the columns start with an upper case letter and have spaces in several of them. We could convert all the column names to lower case and deal with the spacing using some `{dplyr}` functions or base R, or we could just use `options()`! 
 
 ```{r, message = FALSE}
 library(xportr)
@@ -125,52 +114,7 @@ library(dplyr)
 library(haven)
 
 data("adsl_xportr", "var_spec", "dataset_spec", package = "xportr")
-colnames(var_spec)
 ADSL <- adsl_xportr
-```
-
-By using `options()` or `xportr_options()` at the beginning of our script we can tell `{xportr}` what the valid names are (see chunk below). Please note that before we set the options the package assumed every thing was in lowercase and there were no spaces in the names. After running `options()` or `xportr_options()`, `{xportr}` sees the column `Variable` as the valid name rather than `variable`.  You can inspect `xportr_options` function docs to look at additional options.
-
-```{r, eval = FALSE}
-xportr_options(
-  xportr.variable_name = "Variable",
-  xportr.label = "Label",
-  xportr.type_name = "Data Type",
-  xportr.format = "Format",
-  xportr.length = "Length",
-  xportr.order_name = "Order"
-)
-
-# Or alternatively
-options(
-  xportr.variable_name = "Variable",
-  xportr.label = "Label",
-  xportr.type_name = "Data Type",
-  xportr.format = "Format",
-  xportr.length = "Length",
-  xportr.order_name = "Order"
-)
-```
-
-## Are we being too verbose?
-
-One final note on the options.  4 of the core `{xportr}` functions have the ability to set messaging as `"none", "message", "warn", "stop"`. Setting each of these in all your calls can be a bit repetitive.  You can use `options()` or `xportr_options()` to set these at a higher level and avoid this repetition.
-
-```{r, eval = FALSE}
-# Default verbose is set to `none`
-xportr_options(
-  xportr.format_verbose = "none",
-  xportr.label_verbose = "none",
-  xportr.length_verbose = "none",
-  xportr.type_verbose = "none"
-)
-
-xportr_options(
-  xportr.format_verbose = "none", # Disables any messaging, keeping the console output clean
-  xportr.label_verbose = "message", # Sends a standard message to the console
-  xportr.length_verbose = "warn", # Sends a warning message to the console
-  xportr.type_verbose = "stop" # Stops execution and sends an error message to the console
-)
 ```
 
 ## Going meta

--- a/vignettes/options.Rmd
+++ b/vignettes/options.Rmd
@@ -1,0 +1,219 @@
+---
+title: "You got options"
+output:
+  rmarkdown::html_vignette:
+    toc: true
+    check_title: TRUE
+vignette: >
+  %\VignetteIndexEntry{You got options}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = " "
+)
+
+options(cli.num_colors = 1)
+```
+
+```{r, include=FALSE}
+# Used to control str() output later on
+
+local({
+  hook_output <- knitr::knit_hooks$get("output")
+  knitr::knit_hooks$set(output = function(x, options) {
+    if (!is.null(options$max.height)) {
+      options$attr.output <- c(
+        options$attr.output,
+        sprintf('style="max-height: %s;"', options$max.height)
+      )
+    }
+    hook_output(x, options)
+  })
+})
+```
+
+```{css, echo=FALSE}
+/* Used to control DT outputs */
+.text-left {
+  text-align: left;
+}
+```
+
+# Introduction
+
+Before we dive into the `{xportr}` functions, we want to point out some quality of life utilities to make your `xpt` generation life a little bit easier.
+
+* `options()`
+* `xportr_options()`
+
+**NOTE:** As long as you have a well-defined _metadata object_ you do NOT need to use `options()` or `xportr_options()`, but we find these handy to use and think they deserve a quick mention!
+
+R has a built-in mechanism for storing global settings called `options()`. You set them with `options()` and retrieve a single value with `getOption()`. Options live for the duration of your R session - once set, any function that reads that option will pick up the new value without you having to pass it as an argument every time. All `{xportr}` options are prefixed with `xportr.` to avoid clashing with options from other packages.
+
+We will also explore the following in this vignette:
+
+* You've got `options()` or `xportr_options()` — column name mapping
+* Are we being too verbose? — verbose messaging defaults
+* Type coercion options
+* Putting it all together
+
+# You've got `options()` or `xportr_options()`
+
+`{xportr}` is built with certain assumptions around specification column names and information in those columns. We have found that each company specification file can differ slightly from our assumptions. For example, one company might call a column `Variables`, another `Variable` and another `variables`. Rather than trying to regex ourselves out of this situation, we have introduced `options()`.
+
+Additionally, we have a helper function `xportr_options()`, which works just like `options()` but it can also be used to get the current state of all `{xportr}` options — we will use this at the end of the vignette.
+
+```{r}
+library(xportr)
+```
+
+Let's look at our example specification file column names available in this package. We can see that all the columns start with an upper case letter and have spaces in several of them. We could convert all the column names to lower case and deal with the spacing using some `{dplyr}` functions or base R, or we could just use `options()`!
+
+```{r}
+data("adsl_xportr", "var_spec", "dataset_spec", package = "xportr")
+colnames(var_spec)
+```
+
+By using `options()` or `xportr_options()` at the beginning of our script we can tell `{xportr}` what the valid names are (see chunk below). Please note that before we set the options the package assumed everything was in lowercase and there were no spaces in the names. After running `options()` or `xportr_options()`, `{xportr}` sees the column `Variable` as the valid name rather than `variable`. You can inspect `?xportr_options` to look at additional options.
+
+```{r, eval = FALSE}
+xportr_options(
+  xportr.variable_name = "Variable",
+  xportr.label = "Label",
+  xportr.type_name = "Data Type",
+  xportr.format_name = "Format",
+  xportr.length = "Length",
+  xportr.order_name = "Order"
+)
+
+# Or alternatively
+options(
+  xportr.variable_name = "Variable",
+  xportr.label = "Label",
+  xportr.type_name = "Data Type",
+  xportr.format_name = "Format",
+  xportr.length = "Length",
+  xportr.order_name = "Order"
+)
+```
+
+Below is the full list of column name options and their defaults.
+
+| Option | Default | Controls |
+|---|---|---|
+| `xportr.domain_name` | `"dataset"` | Domain/dataset name column in variable metadata |
+| `xportr.variable_name` | `"variable"` | Variable name column |
+| `xportr.type_name` | `"type"` | Variable type column |
+| `xportr.label` | `"label"` | Variable label column |
+| `xportr.length` | `"length"` | Variable length column |
+| `xportr.order_name` | `"order"` | Variable order column |
+| `xportr.format_name` | `"format"` | Variable format column |
+| `xportr.df_domain_name` | `"dataset"` | Domain name column in dataset metadata |
+| `xportr.df_label` | `"label"` | Dataset label column in dataset metadata |
+
+# Are we being too verbose?
+
+One final note on the options.  Five of the core `{xportr}` functions have the ability to set messaging as `"none"`, `"message"`, `"warn"`, `"stop"`. Setting each of these in all your calls can be a bit repetitive.  You can use `options()` or `xportr_options()` to set these at a higher level and avoid this repetition.
+
+| Value | Behavior |
+|---|---|
+| `"none"` | Disables any messaging, keeping the console output clean (default) |
+| `"message"` | Sends a standard message to the console |
+| `"warn"` | Sends a warning message to the console |
+| `"stop"` | Stops execution and sends an error message to the console |
+
+```{r, eval = FALSE}
+# Default verbose is set to `none`
+xportr_options(
+  xportr.type_verbose = "none",
+  xportr.label_verbose = "none",
+  xportr.length_verbose = "none",
+  xportr.order_verbose = "none",
+  xportr.format_verbose = "none"
+)
+
+xportr_options(
+  xportr.type_verbose = "message", # Sends a standard message to the console
+  xportr.label_verbose = "message",
+  xportr.length_verbose = "warn", # Sends a warning message to the console
+  xportr.order_verbose = "warn",
+  xportr.format_verbose = "stop" # Stops execution and sends an error message to the console
+)
+```
+
+Note that any per-call `verbose` argument still overrides the option, so you can always tighten or loosen the level for a specific call without changing the global default.
+
+# Type coercion options
+
+`{xportr}` also needs to know which R classes map to character XPT types and which map to numeric XPT types.  These are unlikely to need changing unless your specification file uses non-standard type labels (e.g., `"INT"` instead of `"integer"`), but they are configurable if needed.
+
+| Option | Default | Controls |
+|---|---|---|
+| `xportr.character_types` | `"character"` | R classes treated as character in type coercion |
+| `xportr.character_metadata_types` | `"character"`, `"char"`, `"text"`, `"date"`, … | Metadata type strings mapped to character XPT |
+| `xportr.numeric_types` | `"integer"`, `"float"`, `"numeric"`, `"posixct"`, … | R classes treated as numeric in type coercion |
+| `xportr.numeric_metadata_types` | `"integer"`, `"numeric"`, `"num"`, `"float"` | Metadata type strings mapped to numeric XPT |
+
+```{r, eval = FALSE}
+# Tell xportr that "INT" in your spec means integer/numeric
+xportr_options(
+  xportr.numeric_metadata_types = c("integer", "numeric", "num", "float", "INT")
+)
+```
+
+# Putting it all together
+
+A typical script might start with a single `xportr_options()` block that configures everything up front. After that, all `{xportr}` calls pick up the settings automatically — no need to repeat yourself in every function call!
+
+```{r, eval = FALSE}
+library(xportr)
+
+xportr_options(
+  # Column name mapping for our spec file
+  xportr.variable_name = "Variable",
+  xportr.label = "Label",
+  xportr.type_name = "Data Type",
+  xportr.format_name = "Format",
+  xportr.length = "Length",
+  xportr.order_name = "Order",
+  # Messaging preferences
+  xportr.type_verbose = "message",
+  xportr.label_verbose = "message",
+  xportr.length_verbose = "warn",
+  xportr.order_verbose = "warn",
+  xportr.format_verbose = "none"
+)
+
+ADSL |>
+  xportr_metadata(var_spec, "ADSL") |>
+  xportr_type() |>
+  xportr_length(length_source = "metadata") |>
+  xportr_label() |>
+  xportr_order() |>
+  xportr_format() |>
+  xportr_df_label(dataset_spec) |>
+  xportr_write("adsl.xpt")
+```
+
+You can confirm what is currently set at any time by calling `xportr_options()` with no arguments, or use base R's `getOption()` for a single value:
+
+```{r}
+xportr_options()
+getOption("xportr.label")
+getOption("xportr.type_verbose")
+```
+
+Options persist for the life of your R session.  To reset a single option back to its default, set it explicitly:
+
+```{r, eval = FALSE}
+options(xportr.label = "label")
+
+# Or equivalently
+xportr_options(xportr.label = "label")
+```
+
+To reset **all** xportr options at once, restart your R session or use `withr::with_options()` to scope changes to a block of code without permanently affecting the global state.


### PR DESCRIPTION
### Thank you for your Pull Request!

We have developed a Pull Request template to aid you and our reviewers. Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the xportr codebase remains robust and consistent.

### The scope of `{xportr}`

`{xportr}`'s scope is to enable R users to write out submission compliant `xpt` files that can be delivered to a Health Authority or to downstream validation software programs. We see labels, lengths, types, ordering and formats from a dataset specification object (SDTM and ADaM) as being our primary focus. We also see messaging and warnings to users around applying information from the specification file as a primary focus. Please make sure your Pull Request meets this **scope of {xportr}**. If your Pull Request moves beyond this scope, please get in touch with the `{xportr}` team on [slack](https://pharmaverse.slack.com/archives/C030EB2M4GM) or create an issue to discuss.

Please check off each task box as an acknowledgment that you completed the task. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `main` branch until you have checked off each task.

### Changes Description

Closes #353

Created vignettes/options.Rmd ("You got options") and moved the options sections out of the Deep Dive. The new vignette covers: a quick R options section, all column-name options, verbose messaging options, type coercion options and a example showing both xportr_options() and base options() patterns

Deep Dive now has a brief mention and a link to the new vignette

xportr_options() with no arguments already prints all options to the console, so no new function was needed



### Task List

- [x] The spirit of xportr is met in your Pull Request
- [x] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [x] Summary of changes filled out in the above Changes Description. Can be removed or left blank if changes are minor/self-explanatory.
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/). Use `styler` package and functions to style files accordingly.
- [x] New functions or arguments follow established convention found in the [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers).
- [x] Updated relevant unit tests or have written new unit tests. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Unit-Tests) for conventions used in this package.
- [x] Creation/updated relevant roxygen headers and examples. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers) for conventions used in this package.
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [x] Run `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new/updated functions occur on the "Reference" page.
- [x] Update `NEWS.md` if the changes pertain to a user-facing function (i.e. it has an `@export` tag) or documentation aimed at users (rather than developers)
- [x] The `NEWS.md` entry should go under the `# xportr development version` section. Don't worry about updating the version because it will be auto-updated using the `vbump.yaml` CI.
- [x] Address any updates needed for vignettes and/or templates.
- [x] Link the issue Development Panel so that it closes after successful merging.
- [x] The developer is responsible for fixing merge conflicts not the Reviewer.
- [x] Pat yourself on the back for a job well done! Much love to your accomplishment!
